### PR TITLE
Fix cache cleanup logic in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -146,7 +146,7 @@ self.addEventListener('activate', event => {
                     const validPrefixes = Object.values(CACHE_CONFIG.prefixes);
                     return Promise.all(
                         cacheNames
-                            .filter(name => validPrefixes.some(prefix => !name.startsWith(prefix)))
+                            .filter(name => !validPrefixes.some(prefix => name.startsWith(prefix)))
                             .map(name => caches.delete(name))
                     );
                 }),


### PR DESCRIPTION
## Summary
- ensure cache cleanup removes caches that don't match valid prefixes

## Testing
- `node test/generateStableId.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6854b8534b088328873cbe984c8bfc7a