### PR TITLE
Remove dark mode option

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,14 +10,6 @@
   --transition: all 0.3s ease;
 }
 
-body.dark-mode {
-  --primary-color: #212529;
-  --secondary-color: #adb5bd;
-  --accent-color: #0d6efd;
-  --text-color: #f8f9fa;
-  --background-color: #121212;
-  --box-shadow: 0 2px 5px rgba(255, 255, 255, 0.1);
-}
 
 /* Base Styles */
 html,
@@ -101,14 +93,6 @@ h1 {
   color: #fff;
 }
 
-#theme-toggle {
-  background: none;
-  border: none;
-  color: #fff;
-  padding: 0.25rem;
-  margin-right: 0.5rem;
-  font-size: 1.2rem;
-}
 
 #cart-count {
   position: absolute;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -259,32 +259,6 @@ const debounce = (func, delay) => {
     };
 };
 
-// Theme handling utilities
-function applyTheme(theme) {
-    if (theme === 'dark') {
-        document.body.classList.add('dark-mode');
-    } else {
-        document.body.classList.remove('dark-mode');
-    }
-
-    const icon = document.getElementById('theme-icon');
-    if (icon) {
-        icon.className = theme === 'dark' ? 'bi bi-sun' : 'bi bi-moon';
-    }
-}
-
-function toggleTheme() {
-    const newTheme = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
-    localStorage.setItem('theme', newTheme);
-    applyTheme(newTheme);
-}
-
-function initTheme() {
-    const stored = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = stored || (prefersDark ? 'dark' : 'light');
-    applyTheme(theme);
-}
 
 // Add this utility function for generating stable product IDs
 const generateStableId = (product) => {
@@ -932,13 +906,6 @@ if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', function() {
         // Register service worker first
         registerServiceWorker();
-
-        // Theme setup
-        initTheme();
-        const themeToggle = document.getElementById('theme-toggle');
-        if (themeToggle) {
-            themeToggle.addEventListener('click', toggleTheme);
-        }
 
         // Then initialize the app
         initApp().catch(error => {

--- a/pages/navbar.html
+++ b/pages/navbar.html
@@ -8,9 +8,6 @@
             <button class="navbar-toggler me-2" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <button id="theme-toggle" class="nav-link text-light btn" type="button" aria-label="Cambiar tema">
-                <i id="theme-icon" class="bi bi-moon"></i>
-            </button>
             <a class="nav-link text-light" href="#" id="cart-icon" aria-label="Carrito de compras">
                 <i class="bi bi-cart3"></i>
                 <span class="badge bg-danger" id="cart-count">0</span>


### PR DESCRIPTION
## Summary
- remove dark-mode styles and the theme toggle button
- simplify scripts to always use the light theme

## Testing
- `node test/generateStableId.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6855cdd60a7c8328a00e04e6c93d3362