### PR TITLE
Fix offline page and revert binary assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
                 </div>
             </section>
         </div>
-        <div id="offline-indicator" class="alert alert-warning" role="alert" style="display: none;">Actualmente estás sin conexión</div>
+        <div id="offline-indicator" aria-live="assertive" class="alert alert-warning" role="alert" style="display: none;">Actualmente estás sin conexión</div>
     </main>
 
     <footer id="footer-container" role="contentinfo"></footer>

--- a/pages/offline.html
+++ b/pages/offline.html
@@ -13,12 +13,16 @@
         h1 {
             color: #343a40;
         }
+        .actions { margin-top: 20px; }
     </style>
 </head>
 <body>
     <h1>El Rincón de Ébano</h1>
-    <p>Lo sentimos, parece que no tienes conexión a internet en este momento.</p>
-    <p>Por favor, verifica tu conexión e intenta nuevamente.</p>
-    <button onclick="window.location.reload()">Intentar de nuevo</button>
+    <p role="status">Lo sentimos, parece que no tienes conexión a internet en este momento.</p>
+    <p>Puedes volver a la página principal o intentar recargar para reconectar.</p>
+    <div class="actions">
+        <button onclick="window.location.reload()">Intentar de nuevo</button>
+        <a href="/index.html">Ir al inicio</a>
+    </div>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,5 @@
 // Service Worker Configuration
+const TEST_MODE = typeof module !== 'undefined';
 const CACHE_CONFIG = {
     prefixes: {
         static: 'ebano-static-v3',
@@ -104,6 +105,7 @@ const addTimestamp = async (response, type = 'static') => {
 };
 
 // Install event - cache static assets
+if (!TEST_MODE) {
 self.addEventListener('install', event => {
     console.log('Service Worker: Installing...');
     event.waitUntil(
@@ -316,6 +318,7 @@ self.addEventListener('message', event => {
         });
     }
 });
+}
 
 // Helper function to invalidate specific cache
 async function invalidateCache(cacheName) {
@@ -346,3 +349,5 @@ async function invalidateAllCaches() {
         throw error; // Propagate error for proper handling in message response
     }
 }
+
+if (typeof module !== "undefined") { module.exports = { isCacheFresh, addTimestamp }; }

--- a/test/serviceWorker.utils.test.js
+++ b/test/serviceWorker.utils.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { addTimestamp, isCacheFresh } = require('../service-worker.js');
+
+(async () => {
+  const resp = new Response('data');
+  const stamped = await addTimestamp(resp.clone(), 'static');
+  assert.ok(stamped.headers.get('sw-timestamp'), 'timestamp should be added');
+  assert.strictEqual(stamped.headers.get('cache-type'), 'static');
+  assert.strictEqual(isCacheFresh(stamped, 'static'), true, 'fresh response should be fresh');
+
+  const headers = new Headers(stamped.headers);
+  const past = Date.now() - 2 * 24 * 60 * 60 * 1000; // older than cache duration
+  headers.set('sw-timestamp', past.toString());
+  const oldResp = new Response('old', { headers });
+  assert.strictEqual(isCacheFresh(oldResp, 'static'), false, 'stale response should be stale');
+
+  console.log('All tests passed');
+})();


### PR DESCRIPTION
## Summary
- remove binary font assets and bootstrap files
- revert pages to use CDN links and restore fonts via CDN
- keep offline page improvements and accessibility update for offline indicator
- support testing service worker by gating event listeners with `TEST_MODE`

## Testing
- `node test/generateStableId.test.js`
- `node test/serviceWorker.utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68571407cbf083289ffbbfbc9a299560