### PR TITLE
Enhance home hero section with clear CTA and imagery

### DIFF
--- a/index-enhanced.html
+++ b/index-enhanced.html
@@ -93,8 +93,11 @@
         <div class="container my-4">
             <!-- Enhanced Hero Section -->
             <section class="hero-section text-center mb-5">
-                <h1 class="display-4 fw-bold mb-3">Delivery a su puerta, al instante</h1>
-                <p class="lead text-muted mb-4">Tu minimarket favorito, ahora con delivery express</p>
+                <!-- TODO: replace with real fresh-product hero image at assets/images/hero-fresh-produce.jpg -->
+                <img src="assets/images/hero-fresh-produce.jpg" alt="Productos frescos listos para entrega" class="img-fluid mb-4">
+                <h1 class="display-4 fw-bold mb-3">Productos frescos directo a tu puerta</h1>
+                <p class="lead text-muted mb-4">Compra en línea y recibe en minutos</p>
+                <a href="#product-container" class="btn btn-primary btn-lg mb-4">Ver productos</a>
 
                 <!-- Enhanced Search and Filter -->
                 <div class="search-filter-container mb-5">

--- a/index.html
+++ b/index.html
@@ -87,6 +87,13 @@
     
     <main data-category="" role="main">
         <div class="container my-4">
+            <section class="hero-section text-center mb-5" aria-labelledby="main-heading">
+                <!-- TODO: replace with real fresh-product hero image at assets/images/hero-fresh-produce.jpg -->
+                <img src="assets/images/hero-fresh-produce.jpg" alt="Productos frescos listos para entrega" class="img-fluid mb-4">
+                <h1 id="main-heading">Productos frescos directo a tu puerta</h1>
+                <p class="lead text-muted mb-4">Compra en línea y recibe en minutos</p>
+                <a href="#product-container" class="btn btn-primary btn-lg">Ver productos</a>
+            </section>
             <section aria-label="Opciones de filtrado y ordenación">
                 <div class="row mb-3">
                     <div class="col-md-6">
@@ -103,8 +110,8 @@
                     </div>
                 </div>
             </section>
-            <section aria-labelledby="main-heading">
-                <h1 id="main-heading">Delivery a su puerta, al instante</h1>
+            <section aria-labelledby="products-heading">
+                <h2 id="products-heading" class="visually-hidden">Productos disponibles</h2>
                 <div class="row" id="product-container" aria-live="polite">
                     <!-- Loading skeletons -->
                     <div class="col-12 col-sm-6 col-md-4 col-lg-3 mb-4" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Replace generic home hero heading with a clearer value proposition
- Add subheading, call-to-action button, and placeholder for fresh-product image

## Testing
- `npm test` (fails: ReferenceError: document is not defined)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f3f3cc6483289b3e5cfb50c2015c