### PR TITLE
Fix cart quantity controls hydration on page load

### DIFF
--- a/assets/js/script-enhanced-fixed.js
+++ b/assets/js/script-enhanced-fixed.js
@@ -421,12 +421,13 @@ const renderProducts = (products) => {
         `;
 
         fragment.appendChild(productElement);
-        // Hydrate card state from cart
-        updateProductCardState(product.id);
     });
 
     productContainer.innerHTML = '';
     productContainer.appendChild(fragment);
+
+    // Hydrate card state from cart now that elements are in the DOM
+    products.forEach(product => updateProductCardState(product.id));
 
     // Initialize animations
     productAnimations.init();


### PR DESCRIPTION
## Summary
- Hydrate cart controls only after products are inserted into the DOM so stored cart quantities are shown on reload.

## Testing
- `npm test`
- Node `jsdom` script to verify quantity controls display for items already in cart


------
https://chatgpt.com/codex/tasks/task_e_68b26c64ee9c832889082cde4e981b97