### PR TITLE
Add fetchProducts tests with MockAgent

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1156,7 +1156,7 @@ if (typeof document !== 'undefined') {
     });
 }
 if (typeof module !== 'undefined') {
-    module.exports = { generateStableId };
+    module.exports = { generateStableId, fetchProducts };
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.25.8",
-        "sharp": "^0.33.5"
+        "sharp": "^0.33.5",
+        "undici": "^7.15.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1176,6 +1177,16 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "icons": "node generate-icons.js",
     "images:variants": "node scripts/generate-image-variants.js",
     "prune:backups": "node scripts/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js"
   },
   "keywords": [],
   "author": "",
@@ -19,7 +19,8 @@
   "type": "commonjs",
   "devDependencies": {
     "esbuild": "^0.25.8",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "undici": "^7.15.0"
   },
   "dependencies": {
     "ejs": "^3.1.10"


### PR DESCRIPTION
## Summary
- export `fetchProducts` for reuse in tests
- add `node:test` suite using undici's `MockAgent` to simulate fetch success, missing version, error responses and invalid JSON
- register new test and undici dependency in `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b26f70f21c8328b3f5cd4f8a833678