### PR TITLE
Add tests for service worker cache invalidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "icons": "node generate-icons.js",
     "images:variants": "node scripts/generate-image-variants.js",
     "prune:backups": "node scripts/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js"
   },
   "keywords": [],
   "author": "",

--- a/service-worker.js
+++ b/service-worker.js
@@ -338,5 +338,13 @@ async function invalidateAllCaches() {
     }
 }
 
-if (typeof module !== "undefined") { module.exports = { isCacheFresh, addTimestamp }; }
+if (typeof module !== "undefined") {
+    module.exports = {
+        isCacheFresh,
+        addTimestamp,
+        invalidateCache,
+        invalidateAllCaches,
+        CACHE_CONFIG
+    };
+}
 

--- a/test/swCache.test.js
+++ b/test/swCache.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { invalidateCache, invalidateAllCaches, CACHE_CONFIG } = require('../service-worker.js');
+
+function createCachesMock() {
+  const stores = new Map();
+  return {
+    open: async (name) => {
+      if (!stores.has(name)) stores.set(name, new Map());
+      const cache = stores.get(name);
+      return {
+        put: async (req, res) => { cache.set(req, res); },
+        delete: async (req) => cache.delete(req),
+        keys: async () => Array.from(cache.keys())
+      };
+    },
+    keys: async () => Array.from(stores.keys()),
+    delete: async (name) => stores.delete(name)
+  };
+}
+
+test('invalidateCache deletes all entries for a specific cache', async () => {
+  global.caches = createCachesMock();
+  const cacheName = 'test-cache';
+  const cache = await caches.open(cacheName);
+  await cache.put('a', new Response('1'));
+  await cache.put('b', new Response('2'));
+
+  assert.strictEqual((await cache.keys()).length, 2);
+
+  await invalidateCache(cacheName);
+
+  assert.strictEqual((await cache.keys()).length, 0);
+});
+
+test('invalidateAllCaches removes only caches matching configured prefixes', async () => {
+  global.caches = createCachesMock();
+  const { static: staticPrefix, dynamic: dynamicPrefix } = CACHE_CONFIG.prefixes;
+  const unrelated = 'unrelated-cache';
+
+  await (await caches.open(staticPrefix)).put('a', new Response('1'));
+  await (await caches.open(dynamicPrefix)).put('b', new Response('2'));
+  await (await caches.open(unrelated)).put('c', new Response('3'));
+
+  assert.deepStrictEqual((await caches.keys()).sort(), [staticPrefix, dynamicPrefix, unrelated].sort());
+
+  await invalidateAllCaches();
+
+  assert.deepStrictEqual(await caches.keys(), [unrelated]);
+});


### PR DESCRIPTION
## Summary
- Export cache invalidation helpers from the service worker for testing
- Add tests verifying cache and global cache invalidation behavior
- Run swCache tests via the npm test script

## Testing
- `npm test` *(fails: window.showConnectivityNotification is not a function in notifications.test.js)*
- `node test/swCache.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b27639caac83289a60ff798e5ccd92