### PR TITLE
Add DOM module integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "icons": "node generate-icons.js",
     "images:variants": "node scripts/generate-image-variants.js",
     "prune:backups": "node scripts/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- test keyboard navigation and style injection in `setupNavigationAccessibility`
- ensure PWA manifest and SEO metadata injections operate correctly
- fix notification tests to run scripts in a VM context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27785c2f0832889702b816e5b2ebd