### PR TITLE
Remove inline CSS onload handler from 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,10 +6,15 @@
     <meta name="description" content="Página no encontrada - El Rincón de Ébano">
     <link rel="canonical" href="https://elrincondeebano.com/">
     <link rel="manifest" href="/app.webmanifest">
+    <script src="assets/js/csp.js"></script>
     <title>Página No Encontrada - El Rincón de Ébano</title>
     <link rel="stylesheet" href="assets/css/404.css">
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:wght@400;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:wght@400;700&display=swap"></noscript>
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:wght@400;700&display=swap" media="print" data-defer>
+    <noscript>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:wght@400;700&display=swap">
+    </noscript>
 
     <!-- Preload critical assets -->
     <link rel="preload" href="assets/images/web/404.webp" as="image" type="image/webp">


### PR DESCRIPTION
## Summary
- eliminate inline `onload` handler in 404 page
- load fonts with `data-defer` and enable via CSP script for CSP compliance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b282876b888328be139d031a08184c