### PR TITLE
Fix missing bundle preventing product rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"
         integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy"
         crossorigin="anonymous"></script>
-    <script type="module" src="assets/js/script.js"></script>
+    <script src="assets/js/script.min.js"></script>
 
     <!-- Service Worker registration handled in assets/js/script.min.js -->
 </body>


### PR DESCRIPTION
## Summary
- Load the built script bundle so the app initializes and products render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5bc97d3d083288f4506406e2b76c5