### PR TITLE
Add daily script integrity check with email alerts

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -1,0 +1,32 @@
+name: Daily integrity tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm test
+      - name: Send failure notification
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.SMTP_SERVER }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: '[URGENT] Website integrity tests failed'
+          to: ${{ secrets.ALERT_EMAIL }}
+          from: ${{ secrets.FROM_EMAIL }}
+          body: |
+            The scheduled tests for elrincondeebano have failed.
+            Please check the workflow logs for details.
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "icons": "node generate-icons.js",
     "images:variants": "node scripts/generate-image-variants.js",
     "prune:backups": "node scripts/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js"
+    "test": "node test/scriptTag.test.js && node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/scriptTag.test.js
+++ b/test/scriptTag.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+// Ensure index.html loads the correct production script without module type
+const html = fs.readFileSync('index.html', 'utf-8');
+const dom = new JSDOM(html);
+
+const script = dom.window.document.querySelector('script[src="assets/js/script.min.js"]');
+assert.ok(script, 'index.html should reference assets/js/script.min.js');
+
+// The script should not be loaded as a module
+assert.ok(!script.type, 'assets/js/script.min.js should not have a type attribute');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add Node test ensuring index.html loads `assets/js/script.min.js` without module type
- schedule daily GitHub Action to run all tests and email on failure
- include new test in `npm test` script

## Testing
- `npm test` *(fails: Error al obtener productos: HTTP error. Status: 500)*

------
https://chatgpt.com/codex/tasks/task_e_68b5be7001988328b76fb2ac6ec784e9