### PR TITLE
Defer non-critical scripts for better LCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <link rel="stylesheet" href="assets/css/critical.min.css">
 
     <!-- Security - XSS Protection -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.8/purify.min.js" integrity="sha384-AsiVBlzbaNOq8OOKcXm2ZVjjKJwiQ9UmzLwfetDjC74OMQdkb6vBHH5QRJH3x1SE" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.8/purify.min.js" integrity="sha384-AsiVBlzbaNOq8OOKcXm2ZVjjKJwiQ9UmzLwfetDjC74OMQdkb6vBHH5QRJH3x1SE" crossorigin="anonymous" defer></script>
 
     <!-- Preload Critical Assets -->
     <link rel="preload" href="assets/images/web/logo.webp" as="image" type="image/webp" fetchpriority="high">
@@ -78,7 +78,7 @@
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-H0YG3RTJVM"></script>
-    <script src="assets/js/gtag-init.js"></script>
+    <script src="assets/js/gtag-init.js" defer></script>
 
     <header id="navbar-container" role="banner" style="min-height:56px"></header>
 


### PR DESCRIPTION
## Summary
- defer DOMPurify and analytics init scripts to reduce render-blocking overhead.

## Testing
- `npm test` *(fails: network failure in fetchProducts)*


------
https://chatgpt.com/codex/tasks/task_e_68b8a47d229c8328aaed371ed08b2220