### PR TITLE
Allow Cloudflare Insights in CSP

### DIFF
--- a/assets/js/csp.js
+++ b/assets/js/csp.js
@@ -32,11 +32,11 @@
 
     const cspPolicy = `
         default-src 'self';
-        script-src 'self' https://www.googletagmanager.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com 'nonce-${cspNonce}';
+        script-src 'self' https://www.googletagmanager.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://static.cloudflareinsights.com 'nonce-${cspNonce}';
         style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com 'nonce-${cspNonce}';
         img-src 'self' data: https:;
         font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net;
-        connect-src 'self' https://www.google-analytics.com;
+        connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com;
         frame-src 'none';
         object-src 'none';
         base-uri 'self';

--- a/src/js/csp.js
+++ b/src/js/csp.js
@@ -32,11 +32,11 @@
 
     const cspPolicy = `
         default-src 'self';
-        script-src 'self' https://www.googletagmanager.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com 'nonce-${cspNonce}';
+        script-src 'self' https://www.googletagmanager.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://static.cloudflareinsights.com 'nonce-${cspNonce}';
         style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com 'nonce-${cspNonce}';
         img-src 'self' data: https:;
         font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net;
-        connect-src 'self' https://www.google-analytics.com;
+        connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com;
         frame-src 'none';
         object-src 'none';
         base-uri 'self';


### PR DESCRIPTION
## Summary
- permit Cloudflare Insights endpoints in CSP script-src and connect-src

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb12e34e04832894dfa7167e009335