### PR TITLE
Add image linting step to build instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ This repository contains the source code for the static website **El Rincón de 
 - Run `npm test` after modifying any code. Add or update tests for new functionality.
 - For changes affecting templates or assets, run `npm run build` to regenerate output.
 - When adding or updating product images, run `npm run images:variants` to produce responsive variants and update manifests.
+- Whenever images are added or modified, run `npm run lint:images` to check dimensions and formats, resolving all issues before committing.
 - Ensure all scripts complete successfully before committing.
 
 ## Commit & PR Guidelines


### PR DESCRIPTION
## Summary
- require `npm run lint:images` whenever images are added or modified

## Testing
- `npm install`
- `npm test` *(fails: HTTP 500/network errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d207cf48328ac8e3872dc9919ec