### PR TITLE
Document pruning backup files after refactors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ This repository contains the source code for the static website **El Rincón de 
 - When adding or updating product images, run `npm run images:variants` to produce responsive variants and update manifests.
 - If the website logo or PWA icons change, run `npm run icons` to regenerate `assets/images/web/icon-192.png` and `icon-512.png`, committing any newly generated files.
 - Whenever images are added or modified, run `npm run lint:images` to check dimensions and formats, resolving all issues before committing.
+- After large refactors or file rewrites, run `npm run prune:backups`. This script ensures no temporary backup files remain before committing.
 - Ensure all scripts complete successfully before committing.
 
 ## Commit & PR Guidelines


### PR DESCRIPTION
## Summary
- mention running `npm run prune:backups` after large refactors or file rewrites to remove temporary backup files before committing

## Testing
- `npm run prune:backups`
- `npm test` *(fails: network failure when fetching products)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5eff1b4483289813715fe1afdbeb