### PR TITLE
Replace gtag script with Google Tag Manager snippet

### DIFF
--- a/dist/js/gtag-init.js
+++ b/dist/js/gtag-init.js
@@ -1,7 +1,0 @@
-// Google Analytics initialization extracted from inline script
-window.dataLayer = window.dataLayer || [];
-function gtag(){ dataLayer.push(arguments); }
-gtag('js', new Date());
-// Prevent duplicate page views (matches previous config on index.html)
-gtag('config', 'G-H0YG3RTJVM', { 'send_page_view': false });
-

--- a/index.html
+++ b/index.html
@@ -7,6 +7,14 @@
     <link rel="canonical" href="https://elrincondeebano.com/">
     <link rel="manifest" href="/app.webmanifest">
 
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-XXXX');</script>
+    <!-- End Google Tag Manager -->
+
     <!-- Security -->
     <script src="dist/js/csp.js?v=2" async=""></script>
 
@@ -66,9 +74,9 @@
 
 <body>
 
-    <!-- Google tag (gtag.js) -->
-    <script async="" src="https://www.googletagmanager.com/gtag/js?id=G-H0YG3RTJVM"></script>
-    <script src="dist/js/gtag-init.js" defer=""></script>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     <header id="navbar-container" role="banner"></header>
 

--- a/src/js/gtag-init.js
+++ b/src/js/gtag-init.js
@@ -1,7 +1,0 @@
-// Google Analytics initialization extracted from inline script
-window.dataLayer = window.dataLayer || [];
-function gtag(){ dataLayer.push(arguments); }
-gtag('js', new Date());
-// Prevent duplicate page views (matches previous config on index.html)
-gtag('config', 'G-H0YG3RTJVM', { 'send_page_view': false });
-

--- a/tools/build.js
+++ b/tools/build.js
@@ -12,7 +12,7 @@ async function build() {
     outfile: path.join(rootDir, 'dist/js/script.min.js'),
   });
 
-  const staticJs = ['csp.js', 'gtag-init.js', 'sw-register.js'];
+  const staticJs = ['csp.js', 'sw-register.js'];
   const distJsDir = path.join(rootDir, 'dist/js');
   fs.mkdirSync(distJsDir, { recursive: true });
   for (const file of staticJs) {


### PR DESCRIPTION
## Summary
- replace legacy gtag snippet in `index.html` with current Google Tag Manager script and noscript tags
- drop unused `gtag-init.js` and adjust build script

## Testing
- `npm test` *(fails: HTTP 500 during product fetch)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdd3b0179c83289eab3d2b1f73e354