### PR TITLE
Enforce same-origin HTTPS fetch URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/fetchProducts.test.js
+++ b/test/fetchProducts.test.js
@@ -12,7 +12,7 @@ let fetchProducts, logs;
     error: msg => logs.push(msg)
   };
   // Minimal DOM stubs for error handling paths
-  global.window = { location: { reload() {} }, addEventListener() {} };
+  global.window = { location: { origin: 'https://localhost', reload() {} }, addEventListener() {} };
   global.document = {
     addEventListener() {},
     createElement: () => ({
@@ -33,9 +33,9 @@ let fetchProducts, logs;
   const mockAgent = new MockAgent();
   mockAgent.disableNetConnect();
   setGlobalDispatcher(mockAgent);
-  const mockPool = mockAgent.get('http://localhost');
+  const mockPool = mockAgent.get('https://localhost');
 
-  global.fetch = (url, opts) => undiciFetch(new URL(url, 'http://localhost').toString(), opts);
+  global.fetch = (url, opts) => undiciFetch(new URL(url, 'https://localhost').toString(), opts);
 
   function setupLocalStorage(initial = {}) {
     const store = { ...initial };

--- a/test/fetchWithRetry.test.js
+++ b/test/fetchWithRetry.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+let fetchWithRetry, lastUrl, fetchCalls;
+
+(async () => {
+  global.console = { log() {}, warn() {}, error() {} };
+  global.window = { location: { origin: 'https://example.com', reload() {} }, addEventListener() {} };
+  global.document = {
+    addEventListener() {},
+    createElement: () => ({
+      setAttribute() {},
+      appendChild() {},
+      addEventListener() {},
+      querySelector() { return { addEventListener() {} }; },
+      remove() {}
+    }),
+    createTextNode: text => ({ textContent: text }),
+    getElementById: () => null,
+    body: { appendChild() {}, contains() { return false; } }
+  };
+
+  ({ fetchWithRetry } = await import('../src/js/script.mjs'));
+
+  function mockFetch(url) {
+    lastUrl = url;
+    fetchCalls++;
+    return Promise.resolve({ ok: true, status: 200 });
+  }
+
+  test('fetchWithRetry URL validation', async (t) => {
+    await t.test('accepts same-origin https path', async () => {
+      fetchCalls = 0;
+      global.fetch = mockFetch;
+      await fetchWithRetry('/data', {}, 0, 0, 'cid');
+      assert.strictEqual(lastUrl, 'https://example.com/data');
+      assert.strictEqual(fetchCalls, 1);
+    });
+
+    await t.test('rejects external origin', async () => {
+      fetchCalls = 0;
+      global.fetch = () => { fetchCalls++; return Promise.resolve({ ok: true, status: 200 }); };
+      await assert.rejects(
+        fetchWithRetry('https://evil.com/data', {}, 0, 0, 'cid'),
+        /same-origin HTTPS/
+      );
+      assert.strictEqual(fetchCalls, 0);
+    });
+
+    await t.test('rejects non-HTTPS protocol', async () => {
+      fetchCalls = 0;
+      global.fetch = () => { fetchCalls++; return Promise.resolve({ ok: true, status: 200 }); };
+      await assert.rejects(
+        fetchWithRetry('http://example.com/data', {}, 0, 0, 'cid'),
+        /same-origin HTTPS/
+      );
+      assert.strictEqual(fetchCalls, 0);
+    });
+  });
+})();

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -14,6 +14,7 @@ const { JSDOM } = require('jsdom');
   function setupDom() {
     const dom = new JSDOM('<!DOCTYPE html><body></body>', { url: 'http://localhost/' });
     dom.window.setTimeout = () => ({ unref() {} });
+    global.setTimeout = dom.window.setTimeout;
     delete dom.window.navigator.serviceWorker;
     dom.window.document.addEventListener = () => {};
     dom.window.location.reload = () => {};


### PR DESCRIPTION
## Summary
- Validate fetch URLs against window origin and HTTPS scheme before retrying
- Export fetchWithRetry and add comprehensive URL validation tests
- Update product fetch tests for HTTPS origin and guard notification reload errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bedaa5939c8328ba00b74b971cf04c