### PR TITLE
Guard service worker registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/js/script.mjs
+++ b/src/js/script.mjs
@@ -8,6 +8,8 @@ const SERVICE_WORKER_CONFIG = {
     updateCheckInterval: 5 * 60 * 1000, // 5 minutes
 };
 
+let serviceWorkerRegistrationSetup = false;
+
 // Enhanced service worker registration with proper error handling and lifecycle management
 function registerServiceWorker() {
     if (!('serviceWorker' in navigator)) {
@@ -15,14 +17,33 @@ function registerServiceWorker() {
         return;
     }
 
-    window.addEventListener('load', async () => {
-        try {
-            initializeServiceWorker();
-        } catch (error) {
-            console.error('Service Worker initialization failed:', error);
-            showServiceWorkerError('Failed to initialize service worker. Some features may not work offline.');
-        }
-    });
+    if (serviceWorkerRegistrationSetup) {
+        return;
+    }
+
+    serviceWorkerRegistrationSetup = true;
+
+    window.addEventListener('load', startRegistration);
+    startRegistration();
+}
+
+async function startRegistration() {
+    if (document.readyState !== 'complete') {
+        return;
+    }
+
+    window.removeEventListener('load', startRegistration);
+
+    try {
+        await initializeServiceWorker();
+    } catch (error) {
+        console.error('Service Worker initialization failed:', error);
+        showServiceWorkerError('Failed to initialize service worker. Some features may not work offline.');
+    }
+}
+
+function __resetServiceWorkerRegistrationForTest() {
+    serviceWorkerRegistrationSetup = false;
 }
 
 // Initialize the service worker and set up event handlers
@@ -1485,6 +1506,8 @@ export {
     showUpdateNotification,
     showServiceWorkerError,
     showConnectivityNotification,
+    registerServiceWorker as __registerServiceWorkerForTest,
+    __resetServiceWorkerRegistrationForTest,
     __getCart,
     __resetCart
 };

--- a/test/registerServiceWorker.test.js
+++ b/test/registerServiceWorker.test.js
@@ -1,0 +1,171 @@
+const assert = require('assert');
+
+(async () => {
+  const originalSetInterval = global.setInterval;
+  const originalSetTimeout = global.setTimeout;
+  global.setInterval = () => 0;
+  global.setTimeout = () => 0;
+
+  const windowListeners = new Map();
+  const documentListeners = new Map();
+  const bodyChildren = new Set();
+
+  const documentMock = {
+    _readyState: 'complete',
+    get readyState() {
+      return this._readyState;
+    },
+    set readyState(value) {
+      this._readyState = value;
+    },
+    addEventListener(event, handler) {
+      documentListeners.set(event, handler);
+    },
+    querySelector(selector) {
+      if (selector === '.notification-toast') {
+        for (const child of bodyChildren) {
+          if (child.className === 'notification-toast') {
+            return child;
+          }
+        }
+      }
+      return null;
+    },
+    getElementById() {
+      return null;
+    },
+    createElement() {
+      const element = {
+        className: '',
+        attributes: {},
+        style: {},
+        setAttribute(name, value) {
+          this.attributes[name] = value;
+        },
+        innerHTML: '',
+        querySelector() {
+          return {
+            addEventListener: () => {},
+            remove: () => {}
+          };
+        },
+        remove() {
+          bodyChildren.delete(element);
+        },
+        classList: {
+          toggle: () => {}
+        }
+      };
+      return element;
+    },
+    body: {
+      appendChild(element) {
+        bodyChildren.add(element);
+      },
+      contains(element) {
+        return bodyChildren.has(element);
+      }
+    }
+  };
+
+  const windowMock = {
+    addEventListener(event, handler) {
+      if (!windowListeners.has(event)) {
+        windowListeners.set(event, new Set());
+      }
+      windowListeners.get(event).add(handler);
+    },
+    removeEventListener(event, handler) {
+      const handlers = windowListeners.get(event);
+      if (!handlers) {
+        return;
+      }
+      handlers.delete(handler);
+      if (handlers.size === 0) {
+        windowListeners.delete(event);
+      }
+    },
+    location: {
+      reload: () => {}
+    },
+    document: documentMock
+  };
+
+  const storage = {};
+  global.localStorage = {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null;
+    },
+    setItem(key, value) {
+      storage[key] = String(value);
+    }
+  };
+
+  let registerCalls = 0;
+  const registrationMock = {
+    scope: '/',
+    addEventListener: () => {},
+    installing: {
+      addEventListener: () => {},
+      state: 'installed',
+      postMessage: () => {}
+    },
+    active: {
+      postMessage: () => {}
+    },
+    update: async () => {}
+  };
+
+  const serviceWorkerMock = {
+    register: async () => {
+      registerCalls += 1;
+      return registrationMock;
+    },
+    addEventListener: () => {},
+    controller: {}
+  };
+
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ version: '1' })
+  });
+
+  global.window = windowMock;
+  global.document = documentMock;
+  Object.defineProperty(globalThis, 'navigator', {
+    value: {
+      serviceWorker: serviceWorkerMock,
+      onLine: true
+    },
+    configurable: true,
+    writable: true
+  });
+
+  windowMock.navigator = global.navigator;
+
+  const module = await import('../src/js/script.mjs');
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.strictEqual(registerCalls, 1, 'service worker should register immediately when document is complete');
+  assert.strictEqual(windowListeners.has('load'), false, 'load listener should be removed after registration');
+
+  module.__resetServiceWorkerRegistrationForTest();
+  document.readyState = 'complete';
+
+  module.__registerServiceWorkerForTest();
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.strictEqual(registerCalls, 2, 'service worker should register after reset');
+  assert.strictEqual(windowListeners.has('load'), false, 'load listener should be cleaned up after reset registration');
+
+  module.__registerServiceWorkerForTest();
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.strictEqual(registerCalls, 2, 'registerServiceWorker should not run multiple times without reset');
+  assert.strictEqual(windowListeners.has('load'), false, 'load listener should not be reattached on repeated calls');
+
+  global.setInterval = originalSetInterval;
+  global.setTimeout = originalSetTimeout;
+
+  console.log('registerServiceWorker tests passed');
+})();


### PR DESCRIPTION
## Summary
- ensure service worker registration only installs the load listener once and exits on repeat calls
- trigger registration immediately when the document is already loaded via a reusable helper
- export testing hooks and add a unit test covering the guarded registration path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e1552938832884d58a5960a3ab6b