### PR TITLE
Await service worker init on load

### DIFF
--- a/src/js/script.mjs
+++ b/src/js/script.mjs
@@ -23,23 +23,23 @@ function registerServiceWorker() {
 
     serviceWorkerRegistrationSetup = true;
 
+    const startRegistration = async () => {
+        if (document.readyState !== 'complete') {
+            return;
+        }
+
+        window.removeEventListener('load', startRegistration);
+
+        try {
+            await initializeServiceWorker();
+        } catch (error) {
+            console.error('Service Worker initialization failed:', error);
+            showServiceWorkerError('Failed to initialize service worker. Some features may not work offline.');
+        }
+    };
+
     window.addEventListener('load', startRegistration);
     startRegistration();
-}
-
-async function startRegistration() {
-    if (document.readyState !== 'complete') {
-        return;
-    }
-
-    window.removeEventListener('load', startRegistration);
-
-    try {
-        await initializeServiceWorker();
-    } catch (error) {
-        console.error('Service Worker initialization failed:', error);
-        showServiceWorkerError('Failed to initialize service worker. Some features may not work offline.');
-    }
 }
 
 function __resetServiceWorkerRegistrationForTest() {


### PR DESCRIPTION
## Summary
- await service worker initialization in the load event handler to honor async flow
- retain existing error handling while preventing duplicate registrations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e446fd288328b7966861881ae0c9