### PR TITLE
Handle absolute product repository paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ secrets.json
 # Test files
 tests/
 test_*.py
+!admin/product_manager/tests/
+!admin/product_manager/tests/test_*.py
 
 # Documentation build
 docs/_build/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ npm test
 
 Se ejecutan pruebas unitarias para utilidades de generación de IDs y el Service Worker.
 
+## Gestor de productos
+
+Las herramientas de administración escritas en Python guardan el catálogo en un archivo JSON. Por omisión el repositorio utiliza `C:\Users\corte\OneDrive\Tienda Ebano\data`, pero también acepta rutas absolutas. Cuando se proporciona una ruta absoluta, el archivo y sus copias de seguridad se crean directamente en el directorio indicado sin generar subcarpetas adicionales.
+
 ## Estructura del proyecto
 
 - `assets/` – Archivos estáticos (CSS, imágenes, fuentes).

--- a/admin/product_manager/tests/test_repository_paths.py
+++ b/admin/product_manager/tests/test_repository_paths.py
@@ -1,0 +1,40 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT_PATH = Path(__file__).resolve().parents[3]
+if str(ROOT_PATH) not in sys.path:
+    sys.path.insert(0, str(ROOT_PATH))
+
+MODULE_PATH = Path(__file__).resolve().parents[1]
+if str(MODULE_PATH) not in sys.path:
+    sys.path.insert(0, str(MODULE_PATH))
+
+from admin.product_manager.models import Product
+from admin.product_manager.repositories import JsonProductRepository
+
+
+def test_absolute_path_uses_provided_directory(tmp_path: Path) -> None:
+    products_path = tmp_path / 'nested' / 'products.json'
+    repo = JsonProductRepository(file_name=str(products_path))
+
+    product = Product(
+        name='Producto de prueba',
+        description='Descripción',
+        price=1000
+    )
+
+    repo.save_products([product])
+
+    assert products_path.exists()
+    assert products_path.parent == repo._file_path.parent
+    with products_path.open(encoding=JsonProductRepository.ENCODING) as handler:
+        saved_data = json.load(handler)
+    assert saved_data['products'][0]['name'] == product.name
+    assert not any(item.name.startswith('C:') for item in tmp_path.iterdir())
+
+    repo.save_products([product])
+    backups = sorted(products_path.parent.glob(f'*{JsonProductRepository.BACKUP_SUFFIX}*'))
+    assert backups, 'Se debe crear un respaldo en el mismo directorio'
+    for backup in backups:
+        assert backup.parent == products_path.parent


### PR DESCRIPTION
## Summary
- ensure `JsonProductRepository` respects absolute file locations and manages backups relative to the resolved directory
- guarantee the repository creates the resolved data folder and reuses it for backups
- add regression coverage for absolute paths and document the supported configuration

## Testing
- pytest admin/product_manager/tests/test_repository_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68d2ea487c508328ab9844d1e6d0542f