### PR TITLE
Simplify ProductService caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Se ejecutan pruebas unitarias para utilidades de generación de IDs y el Service
 
 Las herramientas de administración escritas en Python guardan el catálogo en un archivo JSON. Por omisión el repositorio utiliza `C:\Users\corte\OneDrive\Tienda Ebano\data`, pero también acepta rutas absolutas. Cuando se proporciona una ruta absoluta, el archivo y sus copias de seguridad se crean directamente en el directorio indicado sin generar subcarpetas adicionales.
 
+`ProductService` mantiene un caché en memoria respaldado por una copia defensiva por llamada para `get_all_products()`. Esto garantiza que las listas retornadas puedan modificarse en pruebas o scripts sin alterar el estado interno del servicio.
+
 ## Estructura del proyecto
 
 - `assets/` – Archivos estáticos (CSS, imágenes, fuentes).

--- a/admin/product_manager/services.py
+++ b/admin/product_manager/services.py
@@ -110,7 +110,6 @@ class ProductService:
             except Exception as e:
                 logger.error(f"Error en el manejador de eventos: {e}")
 
-    @lru_cache(maxsize=None)
     def get_all_products(self) -> List[Product]:
         """
         Get all products from the repository.
@@ -118,8 +117,8 @@ class ProductService:
         try:
             with self._products_lock:
                 if self._products is None:
-                    self._products = self.repository.load_products()
-                return self._products.copy()
+                    self._products = list(self.repository.load_products())
+                return list(self._products)
         except ProductRepositoryError as e:
             logger.error(f"Error al cargar productos: {e}")
             raise ProductServiceError(f"Error al cargar productos: {e}")
@@ -281,7 +280,6 @@ class ProductService:
     def clear_cache(self) -> None:
         """Clear all cached data."""
         self._products = None
-        self.get_all_products.cache_clear()
         self.get_categories.cache_clear()
 
     def batch_update(self, updates: List[tuple[str, Product]]) -> None:

--- a/admin/product_manager/tests/test_product_service_get_all.py
+++ b/admin/product_manager/tests/test_product_service_get_all.py
@@ -1,0 +1,57 @@
+import sys
+import types
+from pathlib import Path
+from typing import List
+
+
+if 'portalocker' not in sys.modules:
+  portalocker_stub = types.ModuleType('portalocker')
+  portalocker_stub.LOCK_EX = 0
+  portalocker_stub.LOCK_SH = 0
+
+  def _noop(*_args, **_kwargs) -> None:
+    return None
+
+  portalocker_stub.lock = _noop
+  portalocker_stub.unlock = _noop
+  sys.modules['portalocker'] = portalocker_stub
+
+ROOT_PATH = Path(__file__).resolve().parents[3]
+if str(ROOT_PATH) not in sys.path:
+  sys.path.insert(0, str(ROOT_PATH))
+
+MODULE_PATH = Path(__file__).resolve().parents[1]
+if str(MODULE_PATH) not in sys.path:
+  sys.path.insert(0, str(MODULE_PATH))
+
+from admin.product_manager.models import Product
+from admin.product_manager.services import ProductService
+from admin.product_manager.repositories import ProductRepositoryProtocol
+
+
+class InMemoryRepository(ProductRepositoryProtocol):
+  """Repositorio en memoria para pruebas del servicio."""
+
+  def __init__(self, products: List[Product]):
+    self._products = list(products)
+
+  def load_products(self) -> List[Product]:
+    return list(self._products)
+
+  def save_products(self, products: List[Product]) -> None:
+    self._products = list(products)
+
+
+def test_get_all_products_returns_defensive_copy() -> None:
+  repo = InMemoryRepository([
+      Product(name='Producto 1', description='Descripción', price=1000)
+  ])
+  service = ProductService(repo)
+
+  first_result = service.get_all_products()
+  second_result = service.get_all_products()
+
+  first_result.pop()
+
+  assert len(second_result) == 1
+  assert len(service.get_all_products()) == 1


### PR DESCRIPTION
## Summary
- remove the LRU cache decoration from ProductService.get_all_products and rely on the service-level list with defensive copies
- reset the product cache explicitly in clear_cache while preserving other memoized lookups
- document the per-call defensive copy behaviour and add a regression test ensuring get_all_products returns independent lists

## Testing
- pytest admin/product_manager/tests/test_product_service_get_all.py
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2ec048cf8832887b071d9cadb5fd4