### PR TITLE
Filter out-of-stock items from initial catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
       </section>
       <section aria-labelledby="products-heading">
         <h2 id="products-heading" class="visually-hidden">Productos disponibles</h2>
-        <div class="row" id="product-container" aria-live="polite" data-total-products="141">
+        <div class="row" id="product-container" aria-live="polite" data-total-products="96">
 
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1916647076" aria-label="Product: Toalla Papel Nova Clásica">
             <div class="card">
@@ -268,30 +268,6 @@
             </div>
           </div>
 
-          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4 agotado has-content-visibility has-contain-intrinsic" data-product-id="pid-1253137974" aria-label="Product: Galletas de Limón McKay">
-            <div class="card">
-
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp 800w" sizes="200px" alt="Galletas de Limón McKay" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
-              <div class="card-body">
-                <h3 class="card-title">Galletas de Limón McKay</h3>
-                <p class="card-text">Presentación de 120g</p>
-                <div class="precio-container">
-
-                  <span class="precio" aria-label="Precio">$1.300</span>
-
-                </div>
-                <div class="action-area" data-pid="pid-1253137974">
-                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-1253137974" aria-label="Agregar Galletas de Limón McKay al carrito">Agregar al carrito</button>
-                  <div class="quantity-control is-hidden">
-                    <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
-                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-1253137974">
-                    <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1880044110" aria-label="Product: Cousiño-Macul • Carmenere Reserva, Chivilingo">
             <div class="card">
 
@@ -333,54 +309,6 @@
                   <div class="quantity-control is-hidden">
                     <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
                     <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-102143798">
-                    <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4 agotado has-content-visibility has-contain-intrinsic" data-product-id="pid-1568755018" aria-label="Product: Cachantun • Agua gasificada 1,6L">
-            <div class="card">
-
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp 800w" sizes="200px" alt="Cachantun • Agua gasificada 1,6L" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
-              <div class="card-body">
-                <h3 class="card-title">Cachantun • Agua gasificada 1,6L</h3>
-                <p class="card-text">Envase desechable</p>
-                <div class="precio-container">
-
-                  <span class="precio" aria-label="Precio">$1.500</span>
-
-                </div>
-                <div class="action-area" data-pid="pid-1568755018">
-                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-1568755018" aria-label="Agregar Cachantun • Agua gasificada 1,6L al carrito">Agregar al carrito</button>
-                  <div class="quantity-control is-hidden">
-                    <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
-                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-1568755018">
-                    <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4 agotado has-content-visibility has-contain-intrinsic" data-product-id="pid-1847959995" aria-label="Product: Misiones de Rengo • Sauvignon Blanc">
-            <div class="card">
-
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp 800w" sizes="200px" alt="Misiones de Rengo • Sauvignon Blanc" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
-              <div class="card-body">
-                <h3 class="card-title">Misiones de Rengo • Sauvignon Blanc</h3>
-                <p class="card-text">Vino blanco • Botella de 750mL • 12° G.L.</p>
-                <div class="precio-container">
-
-                  <span class="precio" aria-label="Precio">$4.900</span>
-
-                </div>
-                <div class="action-area" data-pid="pid-1847959995">
-                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-1847959995" aria-label="Agregar Misiones de Rengo • Sauvignon Blanc al carrito">Agregar al carrito</button>
-                  <div class="quantity-control is-hidden">
-                    <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
-                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-1847959995">
                     <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
                   </div>
                 </div>
@@ -463,23 +391,95 @@
             </div>
           </div>
 
-          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4 agotado has-content-visibility has-contain-intrinsic" data-product-id="pid-21464159" aria-label="Product: Cachantun • Agua sin gas 1,6L">
+          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1125083307" aria-label="Product: Queso Llanero 1Kg">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp 800w" sizes="200px" alt="Cachantun • Agua sin gas 1,6L" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/lacteos/Queso-Llanero2.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/lacteos/Queso-Llanero2.webp 800w" sizes="200px" alt="Queso Llanero 1Kg" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
               <div class="card-body">
-                <h3 class="card-title">Cachantun • Agua sin gas 1,6L</h3>
-                <p class="card-text">Envase desechable</p>
+                <h3 class="card-title">Queso Llanero 1Kg</h3>
+                <p class="card-text">A granel, trozo</p>
                 <div class="precio-container">
 
-                  <span class="precio" aria-label="Precio">$1.500</span>
+                  <span class="precio" aria-label="Precio">$10.000</span>
 
                 </div>
-                <div class="action-area" data-pid="pid-21464159">
-                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-21464159" aria-label="Agregar Cachantun • Agua sin gas 1,6L al carrito">Agregar al carrito</button>
+                <div class="action-area" data-pid="pid-1125083307">
+                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-1125083307" aria-label="Agregar Queso Llanero 1Kg al carrito">Agregar al carrito</button>
                   <div class="quantity-control is-hidden">
                     <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
-                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-21464159">
+                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-1125083307">
+                    <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-954280372" aria-label="Product: Coca-Cola Zero 3L">
+            <div class="card">
+
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 800w" sizes="200px" alt="Coca-Cola Zero 3L" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <div class="card-body">
+                <h3 class="card-title">Coca-Cola Zero 3L</h3>
+                <p class="card-text">Envase retornable</p>
+                <div class="precio-container">
+
+                  <span class="precio" aria-label="Precio">$3.600</span>
+
+                </div>
+                <div class="action-area" data-pid="pid-954280372">
+                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-954280372" aria-label="Agregar Coca-Cola Zero 3L al carrito">Agregar al carrito</button>
+                  <div class="quantity-control is-hidden">
+                    <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
+                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-954280372">
+                    <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1329819949" aria-label="Product: Kross lata 470cc">
+            <div class="card">
+
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/cervezas/Kross%20lata%20470mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/cervezas/Kross%20lata%20470mL.webp 800w" sizes="200px" alt="Kross lata 470cc" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <div class="card-body">
+                <h3 class="card-title">Kross lata 470cc</h3>
+                <p class="card-text">Cerveza Golden Pale Ale</p>
+                <div class="precio-container">
+
+                  <span class="precio" aria-label="Precio">$2.200</span>
+
+                </div>
+                <div class="action-area" data-pid="pid-1329819949">
+                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-1329819949" aria-label="Agregar Kross lata 470cc al carrito">Agregar al carrito</button>
+                  <div class="quantity-control is-hidden">
+                    <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
+                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-1329819949">
+                    <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1556319884" aria-label="Product: Galletas Niza McKay">
+            <div class="card">
+
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 800w" sizes="200px" alt="Galletas Niza McKay" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <div class="card-body">
+                <h3 class="card-title">Galletas Niza McKay</h3>
+                <p class="card-text">Presentación de 150g</p>
+                <div class="precio-container">
+
+                  <span class="precio" aria-label="Precio">$1.300</span>
+
+                </div>
+                <div class="action-area" data-pid="pid-1556319884">
+                  <button class="btn btn-primary add-to-cart-btn mt-2" data-id="pid-1556319884" aria-label="Agregar Galletas Niza McKay al carrito">Agregar al carrito</button>
+                  <div class="quantity-control is-hidden">
+                    <button class="quantity-btn" data-action="decrease" aria-label="Disminuir cantidad">-</button>
+                    <input type="number" class="quantity-input" value="1" min="1" max="50" aria-label="Cantidad" data-id="pid-1556319884">
                     <button class="quantity-btn" data-action="increase" aria-label="Aumentar cantidad">+</button>
                   </div>
                 </div>
@@ -513,7 +513,7 @@
 </footer>
 
 
-  <script type="application/json" id="product-data">{"version":"20250901-215509","totalProducts":141,"initialProducts":[{"name":"Toalla Papel Nova Clásica","description":"Dos Rollos de 14m c/u","price":2000,"discount":0,"stock":true,"category":"Limpiezayaseo","image_path":"assets/images/limpieza_y_aseo/Nova Clásica 2x14m.webp","order":0,"id":"pid-1916647076","originalIndex":0,"discounted_price":2000,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 800w"}},{"name":"Harina sin polvos Mont Blanc","description":"Empaque de 1Kg","price":1800,"discount":0,"stock":true,"category":"Despensa","image_path":"assets/images/despensa/Harina Mont Blanc 1Kg.webp","order":1,"id":"pid-1348893728","originalIndex":1,"discounted_price":1800,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 800w"}},{"name":"Coca-Cola 3L","description":"Envase retornable","price":3600,"discount":0,"stock":true,"category":"Bebidas","image_path":"assets/images/bebidas/Coca Cola 3L.webp","order":2,"id":"pid-1027260660","originalIndex":2,"discounted_price":3600,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%203L.webp 800w"}},{"name":"Galletas de Limón McKay","description":"Presentación de 120g","price":1300,"discount":0,"stock":false,"category":"SnacksDulces","image_path":"assets/images/snacks_dulces/Galletas Limón McKay 120g.webp","order":3,"id":"pid-1253137974","originalIndex":3,"discounted_price":1300,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/snacks_dulces/Galletas%20Lim%C3%B3n%20McKay%20120g.webp 800w"}},{"name":"Cousiño-Macul • Carmenere Reserva, Chivilingo","description":"Vino tinto • Botella 750mL • 13,5° G.L.","price":5500,"discount":0,"stock":true,"category":"Vinos","image_path":"assets/images/vinos/Carmenere Reserva Chivilingo Cousiño-Macul botella 750mL.webp","order":4,"id":"pid-1880044110","originalIndex":4,"discounted_price":5500,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 800w"}},{"name":"Benedictino • Agua gasificada 2L","description":"Envase desechable","price":1900,"discount":0,"stock":true,"category":"Aguas","image_path":"assets/images/bebidas/Agua 2L con gas Benedictino.webp","order":5,"id":"pid-102143798","originalIndex":5,"discounted_price":1900,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 800w"}},{"name":"Cachantun • Agua gasificada 1,6L","description":"Envase desechable","price":1500,"discount":0,"stock":false,"category":"Aguas","image_path":"assets/images/bebidas/Agua 1,6L con gas Cachantun.webp","order":6,"id":"pid-1568755018","originalIndex":6,"discounted_price":1500,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%201%2C6L%20con%20gas%20Cachantun.webp 800w"}},{"name":"Misiones de Rengo • Sauvignon Blanc","description":"Vino blanco • Botella de 750mL • 12° G.L.","price":4900,"discount":0,"stock":false,"category":"Vinos","image_path":"assets/images/vinos/Misiones de Rengo Sauvignon Blanc botella 750mL.webp","order":7,"id":"pid-1847959995","originalIndex":7,"discounted_price":4900,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/vinos/Misiones%20de%20Rengo%20Sauvignon%20Blanc%20botella%20750mL.webp 800w"}},{"name":"Tortilla Grande Mexicana Líder","description":"Empaque de 350g","price":2400,"discount":400,"stock":true,"category":"Despensa","image_path":"assets/images/despensa/Tortilla grande mexicana Líder 350g.webp","order":8,"id":"pid-923114180","originalIndex":8,"discounted_price":2000,"discount_percent":17,"is_discounted":true,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 800w"}},{"name":"Mostaza Clásica Great Value","description":"Botella de 397g","price":3000,"discount":0,"stock":true,"category":"Despensa","image_path":"assets/images/despensa/Mostaza Great Value 397g.webp","order":9,"id":"pid-1175486803","originalIndex":9,"discounted_price":3000,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 800w"}},{"name":"Sprite 3L","description":"Envase desechable","price":3600,"discount":0,"stock":true,"category":"Bebidas","image_path":"assets/images/bebidas/Sprite 3L desechable.webp","order":10,"id":"pid-1191183213","originalIndex":10,"discounted_price":3600,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Sprite%203L%20desechable.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Sprite%203L%20desechable.webp 800w"}},{"name":"Cachantun • Agua sin gas 1,6L","description":"Envase desechable","price":1500,"discount":0,"stock":false,"category":"Aguas","image_path":"assets/images/bebidas/Agua 1,6L sin gas Cachantun.webp","order":11,"id":"pid-21464159","originalIndex":11,"discounted_price":1500,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%201%2C6L%20sin%20gas%20Cachantun.webp 800w"}}]}</script>
+  <script type="application/json" id="product-data">{"version":"20250901-215509","totalProducts":96,"initialProducts":[{"name":"Toalla Papel Nova Clásica","description":"Dos Rollos de 14m c/u","price":2000,"discount":0,"stock":true,"category":"Limpiezayaseo","image_path":"assets/images/limpieza_y_aseo/Nova Clásica 2x14m.webp","order":0,"id":"pid-1916647076","originalIndex":0,"discounted_price":2000,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 800w"}},{"name":"Harina sin polvos Mont Blanc","description":"Empaque de 1Kg","price":1800,"discount":0,"stock":true,"category":"Despensa","image_path":"assets/images/despensa/Harina Mont Blanc 1Kg.webp","order":1,"id":"pid-1348893728","originalIndex":1,"discounted_price":1800,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 800w"}},{"name":"Coca-Cola 3L","description":"Envase retornable","price":3600,"discount":0,"stock":true,"category":"Bebidas","image_path":"assets/images/bebidas/Coca Cola 3L.webp","order":2,"id":"pid-1027260660","originalIndex":2,"discounted_price":3600,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%203L.webp 800w"}},{"name":"Cousiño-Macul • Carmenere Reserva, Chivilingo","description":"Vino tinto • Botella 750mL • 13,5° G.L.","price":5500,"discount":0,"stock":true,"category":"Vinos","image_path":"assets/images/vinos/Carmenere Reserva Chivilingo Cousiño-Macul botella 750mL.webp","order":4,"id":"pid-1880044110","originalIndex":4,"discounted_price":5500,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 800w"}},{"name":"Benedictino • Agua gasificada 2L","description":"Envase desechable","price":1900,"discount":0,"stock":true,"category":"Aguas","image_path":"assets/images/bebidas/Agua 2L con gas Benedictino.webp","order":5,"id":"pid-102143798","originalIndex":5,"discounted_price":1900,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 800w"}},{"name":"Tortilla Grande Mexicana Líder","description":"Empaque de 350g","price":2400,"discount":400,"stock":true,"category":"Despensa","image_path":"assets/images/despensa/Tortilla grande mexicana Líder 350g.webp","order":8,"id":"pid-923114180","originalIndex":8,"discounted_price":2000,"discount_percent":17,"is_discounted":true,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 800w"}},{"name":"Mostaza Clásica Great Value","description":"Botella de 397g","price":3000,"discount":0,"stock":true,"category":"Despensa","image_path":"assets/images/despensa/Mostaza Great Value 397g.webp","order":9,"id":"pid-1175486803","originalIndex":9,"discounted_price":3000,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 800w"}},{"name":"Sprite 3L","description":"Envase desechable","price":3600,"discount":0,"stock":true,"category":"Bebidas","image_path":"assets/images/bebidas/Sprite 3L desechable.webp","order":10,"id":"pid-1191183213","originalIndex":10,"discounted_price":3600,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Sprite%203L%20desechable.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Sprite%203L%20desechable.webp 800w"}},{"name":"Queso Llanero 1Kg","description":"A granel, trozo","price":10000,"discount":0,"stock":true,"category":"Lacteos","image_path":"assets/images/lacteos/Queso-Llanero2.webp","order":13,"id":"pid-1125083307","originalIndex":13,"discounted_price":10000,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/lacteos/Queso-Llanero2.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/lacteos/Queso-Llanero2.webp 800w"}},{"name":"Coca-Cola Zero 3L","description":"Envase retornable","price":3600,"discount":0,"stock":true,"category":"Bebidas","image_path":"assets/images/bebidas/Coca Cola Zero 3L.webp","order":15,"id":"pid-954280372","originalIndex":15,"discounted_price":3600,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 800w"}},{"name":"Kross lata 470cc","description":"Cerveza Golden Pale Ale","price":2200,"discount":0,"stock":true,"category":"Cervezas","image_path":"assets/images/cervezas/Kross lata 470mL.webp","order":17,"id":"pid-1329819949","originalIndex":17,"discounted_price":2200,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/cervezas/Kross%20lata%20470mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/cervezas/Kross%20lata%20470mL.webp 800w"}},{"name":"Galletas Niza McKay","description":"Presentación de 150g","price":1300,"discount":0,"stock":true,"category":"SnacksDulces","image_path":"assets/images/snacks_dulces/Galletas Niza McKay 150g.webp","order":21,"id":"pid-1556319884","originalIndex":21,"discounted_price":1300,"discount_percent":0,"is_discounted":false,"image":{"src":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp","srcset":"/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 800w"}}]}</script>
 
   <script src="dist/js/script.min.js" defer></script>
   <!-- Service Worker registration handled in dist/js/script.min.js -->

--- a/tools/build-index.js
+++ b/tools/build-index.js
@@ -111,17 +111,19 @@ function build() {
     })
     .map(({ product }, index) => enrichProduct(product, index));
 
-  const initialProducts = sortedProducts.slice(0, INITIAL_RENDER_COUNT);
+  const availableProducts = sortedProducts.filter(product => product.stock);
+
+  const initialProducts = availableProducts.slice(0, INITIAL_RENDER_COUNT);
 
   const inlinePayload = safeJsonStringify({
     version: productData.version || null,
-    totalProducts: sortedProducts.length,
+    totalProducts: availableProducts.length,
     initialProducts: initialProducts.map(mapProductForInline)
   });
 
   const html = ejs.render(template, {
     products: initialProducts,
-    totalProducts: sortedProducts.length,
+    totalProducts: availableProducts.length,
     inlinePayload
   }, { rmWhitespace: false, filename: TEMPLATE_PATH });
 


### PR DESCRIPTION
## Summary
- filter the sorted product list to exclude out-of-stock entries before generating the initial catalog
- ensure the inline JSON payload and rendered markup only contain in-stock products and report the filtered total count

## Testing
- npm test
- npm run build *(fails: missing bootstrap/js/dist/{collapse,dropdown,offcanvas} modules; existing issue)*
- node tools/build-index.js

------
https://chatgpt.com/codex/tasks/task_e_68d341eefa708328be955f186e03f48c