### PR TITLE
Optimize memoization cache for product filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/js/script.mjs
+++ b/src/js/script.mjs
@@ -327,19 +327,86 @@ if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
 
 
 // Utility functions
+const isCacheableObject = (value) => (typeof value === 'object' && value !== null) || typeof value === 'function';
+
+const createCacheNode = () => ({
+  map: new Map(),
+  weakMap: new WeakMap(),
+  hasValue: false,
+  value: undefined
+});
+
 const memoize = (fn, cacheSize = 100) => {
-    const cache = new Map();
-    return (...args) => {
-        const key = JSON.stringify(args);
-        if (cache.has(key)) return cache.get(key);
-        const result = fn(...args);
-        if (cache.size >= cacheSize) {
-            const oldestKey = cache.keys().next().value;
-            cache.delete(oldestKey);
-        }
-        cache.set(key, result);
-        return result;
-    };
+  if (typeof fn !== 'function') {
+    throw new TypeError('Expected a function to memoize');
+  }
+
+  if (!Number.isFinite(cacheSize) || cacheSize < 0) {
+    cacheSize = 0;
+  }
+
+  const root = createCacheNode();
+  const lru = [];
+
+  const touch = (node) => {
+    const index = lru.indexOf(node);
+    if (index !== -1) {
+      lru.splice(index, 1);
+    }
+    if (cacheSize > 0) {
+      lru.push(node);
+    }
+  };
+
+  const evictIfNeeded = () => {
+    if (cacheSize === 0) {
+      return;
+    }
+    while (lru.length > cacheSize) {
+      const oldest = lru.shift();
+      if (!oldest) {
+        continue;
+      }
+      oldest.hasValue = false;
+      oldest.value = undefined;
+    }
+  };
+
+  const getChildNode = (node, arg) => {
+    const useWeakMap = isCacheableObject(arg);
+    if (useWeakMap) {
+      let next = node.weakMap.get(arg);
+      if (!next) {
+        next = createCacheNode();
+        node.weakMap.set(arg, next);
+      }
+      return next;
+    }
+    if (!node.map.has(arg)) {
+      node.map.set(arg, createCacheNode());
+    }
+    return node.map.get(arg);
+  };
+
+  return (...args) => {
+    if (cacheSize === 0) {
+      return fn(...args);
+    }
+    let node = root;
+    for (let i = 0; i < args.length; i += 1) {
+      node = getChildNode(node, args[i]);
+    }
+    if (node.hasValue) {
+      touch(node);
+      return node.value;
+    }
+    const result = fn(...args);
+    node.value = result;
+    node.hasValue = true;
+    touch(node);
+    evictIfNeeded();
+    return result;
+  };
 };
 
 const debounce = (func, delay) => {
@@ -1886,6 +1953,7 @@ export {
     showConnectivityNotification,
     registerServiceWorker as __registerServiceWorkerForTest,
     __resetServiceWorkerRegistrationForTest,
+    memoize as __memoizeForTest,
     __getCart,
     __resetCart
 };

--- a/test/memoize.test.js
+++ b/test/memoize.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+(async () => {
+  global.console = { log() {}, warn() {}, error() {} };
+
+  const windowListeners = new Map();
+  const documentMock = {
+    readyState: 'loading',
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector() { return null; },
+    getElementById() { return null; },
+    createElement() {
+      return {
+        setAttribute() {},
+        appendChild() {},
+        remove() {},
+        querySelector() { return null; },
+        classList: { add() {}, remove() {}, toggle() {} }
+      };
+    },
+    createTextNode(text) {
+      return { textContent: text };
+    },
+    body: {
+      appendChild() {},
+      contains() { return false; }
+    }
+  };
+
+  const windowMock = {
+    addEventListener(event, handler) {
+      windowListeners.set(event, handler);
+    },
+    removeEventListener() {},
+    location: { reload() {} },
+    document: documentMock
+  };
+
+  const serviceWorkerMock = {
+    register: async () => ({ addEventListener() {}, installing: null, active: null }),
+    addEventListener() {},
+    controller: null
+  };
+
+  global.window = windowMock;
+  global.document = documentMock;
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { serviceWorker: serviceWorkerMock, onLine: true },
+    configurable: true
+  });
+  windowMock.navigator = global.navigator;
+
+  const { __memoizeForTest } = await import('../src/js/script.mjs');
+
+  test('memoize caches results for identical inputs', () => {
+    let calls = 0;
+    const fn = (...args) => {
+      calls += 1;
+      return args.reduce((acc, value) => acc + Number(value || 0), 0);
+    };
+    const memoized = __memoizeForTest(fn, 5);
+    const products = [{ id: 1 }, { id: 2 }];
+
+    const first = memoized(products, 'chocolate', 'price-asc', true);
+    const second = memoized(products, 'chocolate', 'price-asc', true);
+
+    assert.strictEqual(first, second, 'cached result should be reused');
+    assert.strictEqual(calls, 1, 'underlying function should only run once');
+  });
+
+  test('memoize differentiates object identities', () => {
+    let calls = 0;
+    const fn = () => {
+      calls += 1;
+      return calls;
+    };
+    const memoized = __memoizeForTest(fn, 5);
+
+    memoized([{ id: 1 }], 'vino');
+    memoized([{ id: 1 }], 'vino');
+
+    assert.strictEqual(calls, 2, 'different array instances should not share cache entries');
+  });
+
+  test('memoize evicts least recently used entries', () => {
+    let calls = 0;
+    const fn = (value) => {
+      calls += 1;
+      return value;
+    };
+    const memoized = __memoizeForTest(fn, 1);
+
+    memoized('a');
+    memoized('b');
+    memoized('a');
+
+    assert.strictEqual(calls, 3, 'cache should evict oldest entry when size exceeded');
+  });
+})();

--- a/tools/benchmarks/memoize-benchmark.mjs
+++ b/tools/benchmarks/memoize-benchmark.mjs
@@ -1,0 +1,152 @@
+import { performance } from 'node:perf_hooks';
+
+const documentStub = {
+  readyState: 'loading',
+  addEventListener() {},
+  removeEventListener() {},
+  querySelector() { return null; },
+  getElementById() { return null; },
+  createElement() {
+    return {
+      setAttribute() {},
+      appendChild() {},
+      remove() {},
+      querySelector() { return null; },
+      classList: { add() {}, remove() {}, toggle() {} }
+    };
+  },
+  createTextNode(text) {
+    return { textContent: text };
+  },
+  body: {
+    appendChild() {},
+    contains() { return false; }
+  }
+};
+
+const windowStub = {
+  addEventListener() {},
+  removeEventListener() {},
+  location: { reload() {} },
+  document: documentStub
+};
+
+const serviceWorkerStub = {
+  register: async () => ({ addEventListener() {}, installing: null, active: null }),
+  addEventListener() {},
+  controller: null
+};
+
+global.window = windowStub;
+global.document = documentStub;
+Object.defineProperty(globalThis, 'navigator', {
+  value: { serviceWorker: serviceWorkerStub, onLine: true },
+  configurable: true
+});
+windowStub.navigator = global.navigator;
+
+defineLegacyMemoize();
+
+const { __memoizeForTest: optimizedMemoize } = await import('../../src/js/script.mjs');
+
+function defineLegacyMemoize() {
+  global.legacyMemoize = (fn, cacheSize = 100) => {
+    const cache = new Map();
+    return (...args) => {
+      const key = JSON.stringify(args);
+      if (cache.has(key)) {
+        return cache.get(key);
+      }
+      const result = fn(...args);
+      if (cache.size >= cacheSize) {
+        const oldestKey = cache.keys().next().value;
+        cache.delete(oldestKey);
+      }
+      cache.set(key, result);
+      return result;
+    };
+  };
+}
+
+const products = generateProducts(2000);
+const keywords = ['vino', 'cerveza', 'queso', 'chocolate', 'galletas', 'aceite', 'te'];
+const sortCriteria = ['original', 'price-asc', 'price-desc', 'name-asc'];
+const iterations = 5000;
+
+function generateProducts(count) {
+  const items = [];
+  for (let i = 0; i < count; i += 1) {
+    items.push({
+      id: i,
+      name: `Producto ${i}`,
+      description: `Descripción gourmet número ${i}`,
+      price: 500 + (i % 200) * 10,
+      discount: i % 3 === 0 ? 150 : 0,
+      stock: i % 5 !== 0,
+      originalIndex: i
+    });
+  }
+  return items;
+}
+
+function filterScenario(productsList, keyword, sortCriterion, discountOnly = false) {
+  const normalizedKeyword = keyword.toLowerCase();
+  const matches = [];
+  for (let i = 0; i < productsList.length; i += 1) {
+    const product = productsList[i];
+    if (!product.stock) {
+      continue;
+    }
+    if (discountOnly && !(product.discount && product.discount > 0)) {
+      continue;
+    }
+    if (normalizedKeyword) {
+      const name = product.name.toLowerCase();
+      const description = product.description.toLowerCase();
+      if (!name.includes(normalizedKeyword) && !description.includes(normalizedKeyword)) {
+        continue;
+      }
+    }
+    matches.push(product);
+  }
+  switch (sortCriterion) {
+    case 'price-asc':
+      matches.sort((a, b) => (a.price - a.discount) - (b.price - b.discount));
+      break;
+    case 'price-desc':
+      matches.sort((a, b) => (b.price - b.discount) - (a.price - a.discount));
+      break;
+    case 'name-asc':
+      matches.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    default:
+      matches.sort((a, b) => a.originalIndex - b.originalIndex);
+      break;
+  }
+  return matches.length;
+}
+
+function runBenchmark(label, memoizeImpl) {
+  const memoized = memoizeImpl(filterScenario, 200);
+  for (let i = 0; i < keywords.length; i += 1) {
+    memoized(products, keywords[i], sortCriteria[i % sortCriteria.length], i % 2 === 0);
+  }
+  const start = performance.now();
+  for (let i = 0; i < iterations; i += 1) {
+    const keyword = keywords[i % keywords.length];
+    const sortCriterion = sortCriteria[i % sortCriteria.length];
+    const discountOnly = i % 3 === 0;
+    memoized(products, keyword, sortCriterion, discountOnly);
+  }
+  const duration = performance.now() - start;
+  return duration;
+}
+
+const legacyDuration = runBenchmark('legacy', global.legacyMemoize);
+const optimizedDuration = runBenchmark('optimized', optimizedMemoize);
+
+console.log('Memoize benchmark (2000 products,', iterations, 'queries)');
+console.log(`Legacy JSON.stringify cache key: ${legacyDuration.toFixed(2)} ms`);
+console.log(`Optimized structural cache:      ${optimizedDuration.toFixed(2)} ms`);
+console.log(`Speedup: ${(legacyDuration / optimizedDuration).toFixed(2)}x faster`);
+


### PR DESCRIPTION
## Summary
- replace the JSON stringify memoization cache with a structural WeakMap-backed LRU that avoids serializing the product catalog on every lookup
- export the memoizer for verification and add unit coverage to confirm caching, identity checks, and eviction behaviour
- add a synthetic benchmark harness to compare the legacy and optimized memoization implementations

## Testing
- npm test
- node tools/benchmarks/memoize-benchmark.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d34aac52348328b7c54a7877625598