### PR TITLE
Prioritize LCP product image

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/js/script-enhanced-fixed.js
+++ b/src/js/script-enhanced-fixed.js
@@ -389,6 +389,8 @@ const renderProducts = (products) => {
         productElement.style.animationDelay = `${index * 0.1}s`;
 
         const discountedPrice = product.price - (product.discount || 0);
+        const loadingAttr = index === 0 ? 'eager' : 'lazy';
+        const fetchPriorityAttr = index === 0 ? 'high' : 'auto';
 
         productElement.innerHTML = `
             <div class="card h-100">
@@ -402,7 +404,7 @@ const renderProducts = (products) => {
                   "
                   sizes="(max-width: 640px) 200px, 400px"
                   width="400" height="400"
-                  loading="lazy" decoding="async"
+                  loading="${loadingAttr}" fetchpriority="${fetchPriorityAttr}" decoding="async"
                 >
                 <div class="card-body d-flex flex-column">
                     <h5 class="card-title">${product.name}</h5>

--- a/src/js/script.mjs
+++ b/src/js/script.mjs
@@ -1154,6 +1154,7 @@ const initApp = async () => {
                 alt: name,
                 class: 'card-img-top product-thumb',
                 loading: 'lazy',
+                fetchpriority: 'auto',
                 decoding: 'async',
                 width: '400',
                 height: '400'

--- a/templates/index.ejs
+++ b/templates/index.ejs
@@ -32,9 +32,13 @@
   <link rel="dns-prefetch" href="//www.googletagmanager.com">
   <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
 
+  <% const lcpImage = Array.isArray(products) && products.length > 0 ? products[0].image : null; %>
   <!-- Preload critical assets -->
   <link rel="preload" href="/dist/css/critical.min.css" as="style" fetchpriority="high">
   <link rel="preload" href="/assets/images/web/logo.webp" as="image" type="image/webp" fetchpriority="high">
+  <% if (lcpImage) { %>
+  <link rel="preload" href="<%= lcpImage.src %>" as="image" imagesrcset="<%= lcpImage.srcset %>" imagesizes="200px" fetchpriority="high">
+  <% } %>
   <!-- Critical CSS -->
   <link rel="stylesheet" href="dist/css/critical.min.css">
 
@@ -96,13 +100,13 @@
       <section aria-labelledby="products-heading">
         <h2 id="products-heading" class="visually-hidden">Productos disponibles</h2>
         <div class="row" id="product-container" aria-live="polite" data-total-products="<%= totalProducts %>">
-<% products.forEach((product) => { %>
+<% products.forEach((product, index) => { %>
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4 <%= product.stock ? '' : 'agotado' %> has-content-visibility has-contain-intrinsic" data-product-id="<%= product.id %>" aria-label="Product: <%= product.name %>">
             <div class="card">
 <% if (product.isDiscounted) { %>
               <span class="discount-badge badge bg-danger" aria-label="Producto en oferta">-<%= product.discountPercent %>%</span>
 <% } %>
-              <img src="<%= product.image.src %>" srcset="<%= product.image.srcset %>" sizes="200px" alt="<%= product.name %>" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="<%= product.image.src %>" srcset="<%= product.image.srcset %>" sizes="200px" alt="<%= product.name %>" class="card-img-top product-thumb" loading="<%= index === 0 ? 'eager' : 'lazy' %>" fetchpriority="<%= index === 0 ? 'high' : 'auto' %>" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title"><%= product.name %></h3>
                 <p class="card-text"><%= product.description %></p>

--- a/test/buildIndex.lcp.test.js
+++ b/test/buildIndex.lcp.test.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+const templatePath = path.join(__dirname, '..', 'templates', 'index.ejs');
+const template = fs.readFileSync(templatePath, 'utf8');
+
+const sampleProducts = [
+  {
+    id: 'pid-1',
+    name: 'Producto destacado',
+    description: 'Descripción del producto destacado',
+    price: 1990,
+    discountedPrice: 1990,
+    discountPercent: 0,
+    isDiscounted: false,
+    stock: true,
+    image: {
+      src: '/cdn-cgi/image/fit=cover,width=400/sample.webp',
+      srcset: [
+        '/cdn-cgi/image/fit=cover,width=200/sample.webp 200w',
+        '/cdn-cgi/image/fit=cover,width=400/sample.webp 400w',
+        '/cdn-cgi/image/fit=cover,width=800/sample.webp 800w'
+      ].join(', ')
+    }
+  },
+  {
+    id: 'pid-2',
+    name: 'Producto secundario',
+    description: 'Descripción del producto secundario',
+    price: 1490,
+    discountedPrice: 1490,
+    discountPercent: 0,
+    isDiscounted: false,
+    stock: true,
+    image: {
+      src: '/cdn-cgi/image/fit=cover,width=400/sample-2.webp',
+      srcset: [
+        '/cdn-cgi/image/fit=cover,width=200/sample-2.webp 200w',
+        '/cdn-cgi/image/fit=cover,width=400/sample-2.webp 400w'
+      ].join(', ')
+    }
+  }
+];
+
+const html = ejs.render(
+  template,
+  {
+    products: sampleProducts,
+    totalProducts: sampleProducts.length,
+    inlinePayload: '{}'
+  },
+  { filename: templatePath, rmWhitespace: false }
+);
+
+const { document } = new JSDOM(html).window;
+
+const lcpLink = document.querySelector('link[rel="preload"][as="image"][fetchpriority="high"][href="/cdn-cgi/image/fit=cover,width=400/sample.webp"]');
+assert(lcpLink, 'Expected preload link for the LCP image');
+assert.strictEqual(lcpLink.getAttribute('imagesrcset'), sampleProducts[0].image.srcset);
+assert.strictEqual(lcpLink.getAttribute('imagesizes'), '200px');
+
+const productImages = document.querySelectorAll('.product-thumb');
+assert.strictEqual(productImages.length, 2, 'Expected two product thumbnails');
+
+const firstImage = productImages[0];
+assert.strictEqual(firstImage.getAttribute('loading'), 'eager', 'First product must load eagerly');
+assert.strictEqual(firstImage.getAttribute('fetchpriority'), 'high', 'First product must request high fetch priority');
+
+const secondImage = productImages[1];
+assert.strictEqual(secondImage.getAttribute('loading'), 'lazy', 'Subsequent products should remain lazy-loaded');
+assert.strictEqual(secondImage.getAttribute('fetchpriority'), 'auto', 'Subsequent products should use auto fetch priority');
+
+console.log('buildIndex.lcp.test.js passed');


### PR DESCRIPTION
## Summary
- Preload the first product image and mark it for eager loading with high fetch priority in the catalog template
- Ensure dynamic product rendering assigns appropriate fetchpriority attributes both in the main and fallback scripts
- Add a regression test that validates the LCP image markup and wire it into the npm test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d34d64d16083288b08755e45891620