### PR TITLE
Replace GTM snippet with gtag and fix robots sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,15 @@
   <link rel="canonical" href="https://elrincondeebano.com/">
   <link rel="manifest" href="/app.webmanifest">
 
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','G-H0YG3RTJVM');</script>
-  <!-- End Google Tag Manager -->
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-H0YG3RTJVM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-H0YG3RTJVM');
+  </script>
+  <!-- End Google Analytics -->
 
   <!-- Security -->
   <script src="dist/js/csp.js?v=2" async></script>
@@ -32,9 +38,13 @@
   <link rel="dns-prefetch" href="//www.googletagmanager.com">
   <link rel="dns-prefetch" href="//cdnjs.cloudflare.com">
 
+  
   <!-- Preload critical assets -->
   <link rel="preload" href="/dist/css/critical.min.css" as="style" fetchpriority="high">
   <link rel="preload" href="/assets/images/web/logo.webp" as="image" type="image/webp" fetchpriority="high">
+  
+  <link rel="preload" href="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp" as="image" imagesrcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 800w" imagesizes="200px" fetchpriority="high">
+  
   <!-- Critical CSS -->
   <link rel="stylesheet" href="dist/css/critical.min.css">
 
@@ -65,9 +75,6 @@
 </head>
 
 <body>
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=G-H0YG3RTJVM" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
 
   <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
@@ -199,7 +206,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1916647076" aria-label="Product: Toalla Papel Nova Clásica">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 800w" sizes="200px" alt="Toalla Papel Nova Clásica" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/limpieza_y_aseo/Nova%20Cl%C3%A1sica%202x14m.webp 800w" sizes="200px" alt="Toalla Papel Nova Clásica" class="card-img-top product-thumb" loading="eager" fetchpriority="high" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Toalla Papel Nova Clásica</h3>
                 <p class="card-text">Dos Rollos de 14m c/u</p>
@@ -223,7 +230,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1348893728" aria-label="Product: Harina sin polvos Mont Blanc">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 800w" sizes="200px" alt="Harina sin polvos Mont Blanc" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Harina%20Mont%20Blanc%201Kg.webp 800w" sizes="200px" alt="Harina sin polvos Mont Blanc" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Harina sin polvos Mont Blanc</h3>
                 <p class="card-text">Empaque de 1Kg</p>
@@ -247,7 +254,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1027260660" aria-label="Product: Coca-Cola 3L">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%203L.webp 800w" sizes="200px" alt="Coca-Cola 3L" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%203L.webp 800w" sizes="200px" alt="Coca-Cola 3L" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Coca-Cola 3L</h3>
                 <p class="card-text">Envase retornable</p>
@@ -271,7 +278,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1880044110" aria-label="Product: Cousiño-Macul • Carmenere Reserva, Chivilingo">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 800w" sizes="200px" alt="Cousiño-Macul • Carmenere Reserva, Chivilingo" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/vinos/Carmenere%20Reserva%20Chivilingo%20Cousi%C3%B1o-Macul%20botella%20750mL.webp 800w" sizes="200px" alt="Cousiño-Macul • Carmenere Reserva, Chivilingo" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Cousiño-Macul • Carmenere Reserva, Chivilingo</h3>
                 <p class="card-text">Vino tinto • Botella 750mL • 13,5° G.L.</p>
@@ -295,7 +302,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-102143798" aria-label="Product: Benedictino • Agua gasificada 2L">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 800w" sizes="200px" alt="Benedictino • Agua gasificada 2L" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Agua%202L%20con%20gas%20Benedictino.webp 800w" sizes="200px" alt="Benedictino • Agua gasificada 2L" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Benedictino • Agua gasificada 2L</h3>
                 <p class="card-text">Envase desechable</p>
@@ -321,7 +328,7 @@
 
               <span class="discount-badge badge bg-danger" aria-label="Producto en oferta">-17%</span>
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 800w" sizes="200px" alt="Tortilla Grande Mexicana Líder" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Tortilla%20grande%20mexicana%20L%C3%ADder%20350g.webp 800w" sizes="200px" alt="Tortilla Grande Mexicana Líder" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Tortilla Grande Mexicana Líder</h3>
                 <p class="card-text">Empaque de 350g</p>
@@ -346,7 +353,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1175486803" aria-label="Product: Mostaza Clásica Great Value">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 800w" sizes="200px" alt="Mostaza Clásica Great Value" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/despensa/Mostaza%20Great%20Value%20397g.webp 800w" sizes="200px" alt="Mostaza Clásica Great Value" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Mostaza Clásica Great Value</h3>
                 <p class="card-text">Botella de 397g</p>
@@ -370,7 +377,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1191183213" aria-label="Product: Sprite 3L">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Sprite%203L%20desechable.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Sprite%203L%20desechable.webp 800w" sizes="200px" alt="Sprite 3L" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Sprite%203L%20desechable.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Sprite%203L%20desechable.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Sprite%203L%20desechable.webp 800w" sizes="200px" alt="Sprite 3L" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Sprite 3L</h3>
                 <p class="card-text">Envase desechable</p>
@@ -394,7 +401,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1125083307" aria-label="Product: Queso Llanero 1Kg">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/lacteos/Queso-Llanero2.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/lacteos/Queso-Llanero2.webp 800w" sizes="200px" alt="Queso Llanero 1Kg" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/lacteos/Queso-Llanero2.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/lacteos/Queso-Llanero2.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/lacteos/Queso-Llanero2.webp 800w" sizes="200px" alt="Queso Llanero 1Kg" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Queso Llanero 1Kg</h3>
                 <p class="card-text">A granel, trozo</p>
@@ -418,7 +425,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-954280372" aria-label="Product: Coca-Cola Zero 3L">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 800w" sizes="200px" alt="Coca-Cola Zero 3L" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/bebidas/Coca%20Cola%20Zero%203L.webp 800w" sizes="200px" alt="Coca-Cola Zero 3L" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Coca-Cola Zero 3L</h3>
                 <p class="card-text">Envase retornable</p>
@@ -442,7 +449,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1329819949" aria-label="Product: Kross lata 470cc">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/cervezas/Kross%20lata%20470mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/cervezas/Kross%20lata%20470mL.webp 800w" sizes="200px" alt="Kross lata 470cc" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/cervezas/Kross%20lata%20470mL.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/cervezas/Kross%20lata%20470mL.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/cervezas/Kross%20lata%20470mL.webp 800w" sizes="200px" alt="Kross lata 470cc" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Kross lata 470cc</h3>
                 <p class="card-text">Cerveza Golden Pale Ale</p>
@@ -466,7 +473,7 @@
           <div class="producto col-12 col-sm-6 col-md-4 col-lg-3 mb-4  has-content-visibility has-contain-intrinsic" data-product-id="pid-1556319884" aria-label="Product: Galletas Niza McKay">
             <div class="card">
 
-              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 800w" sizes="200px" alt="Galletas Niza McKay" class="card-img-top product-thumb" loading="lazy" decoding="async" width="400" height="400">
+              <img src="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp" srcset="/cdn-cgi/image/fit=cover,quality=82,format=auto,width=200/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 200w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=400/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 400w, /cdn-cgi/image/fit=cover,quality=82,format=auto,width=800/assets/images/snacks_dulces/Galletas%20Niza%20McKay%20150g.webp 800w" sizes="200px" alt="Galletas Niza McKay" class="card-img-top product-thumb" loading="lazy" fetchpriority="auto" decoding="async" width="400" height="400">
               <div class="card-body">
                 <h3 class="card-title">Galletas Niza McKay</h3>
                 <p class="card-text">Presentación de 150g</p>

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Disallow: /admin-web/
 Disallow: /admin-panel/
-https://elrincondeebano.com/sitemap.xml
+Sitemap: https://elrincondeebano.com/sitemap.xml
 

--- a/templates/index.ejs
+++ b/templates/index.ejs
@@ -7,9 +7,15 @@
   <link rel="canonical" href="https://elrincondeebano.com/">
   <link rel="manifest" href="/app.webmanifest">
 
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','G-H0YG3RTJVM');</script>
-  <!-- End Google Tag Manager -->
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-H0YG3RTJVM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-H0YG3RTJVM');
+  </script>
+  <!-- End Google Analytics -->
 
   <!-- Security -->
   <script src="dist/js/csp.js?v=2" async></script>
@@ -69,9 +75,6 @@
 </head>
 
 <body>
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=G-H0YG3RTJVM" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
 
   <%- include('partials/navbar') %>
 


### PR DESCRIPTION
## Summary
- replace the legacy Google Tag Manager bootstrap on the home template with the supported gtag.js snippet and update the generated index.html to stop loading the deprecated API
- remove the obsolete Tag Manager `<noscript>` iframe from the home page output
- declare the sitemap URL with the correct `Sitemap:` directive in robots.txt so crawlers can parse it

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d34f8eb4ec83289fefded5f1fc22fa