### PR TITLE
Fix robots.txt validation and add regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js && node test/robots.test.js"
   },
   "keywords": [],
   "author": "",

--- a/robots.txt
+++ b/robots.txt
@@ -2,4 +2,5 @@ User-agent: *
 Disallow: /admin-web/
 Disallow: /admin-panel/
 Sitemap: https://elrincondeebano.com/sitemap.xml
+# Nota: Las cabeceras HTTP como Content-Signals deben configurarse en el servidor; no deben declararse en este archivo.
 

--- a/test/robots.test.js
+++ b/test/robots.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const robotsPath = path.join(__dirname, '..', 'robots.txt');
+const contents = fs.readFileSync(robotsPath, 'utf8');
+
+const allowedDirectives = new Set([
+  'user-agent',
+  'allow',
+  'disallow',
+  'crawl-delay',
+  'sitemap',
+  'host'
+]);
+
+const lines = contents.split(/\r?\n/);
+lines.forEach((line, index) => {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return;
+  }
+
+  const separatorIndex = trimmed.indexOf(':');
+  assert(
+    separatorIndex !== -1,
+    `Line ${index + 1} must contain a colon separating directive and value`
+  );
+
+  const directive = trimmed.slice(0, separatorIndex).toLowerCase();
+  assert(
+    allowedDirectives.has(directive),
+    `Invalid robots.txt directive "${directive}" on line ${index + 1}`
+  );
+
+  const value = trimmed.slice(separatorIndex + 1).trim();
+  assert(value.length > 0, `Directive on line ${index + 1} must include a value`);
+});
+
+console.log('robots.test.js passed');


### PR DESCRIPTION
## Summary
- document that HTTP Content-Signals headers must be configured outside robots.txt
- add a regression test that fails when unknown directives are introduced in robots.txt
- wire the new test into the npm test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3e9076f8c8328899fc70de554ebde