### PR TITLE
Embed GA snippet and harden analytics handling

### DIFF
--- a/src/js/csp.js
+++ b/src/js/csp.js
@@ -32,11 +32,11 @@
 
     const cspPolicy = `
         default-src 'self';
-        script-src 'self' https://www.googletagmanager.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://static.cloudflareinsights.com 'nonce-${cspNonce}';
+        script-src 'self' https://www.googletagmanager.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://static.cloudflareinsights.com 'unsafe-inline' 'nonce-${cspNonce}';
         style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com 'nonce-${cspNonce}';
         img-src 'self' data: https:;
         font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net;
-        connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com;
+        connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://cdn.jsdelivr.net;
         frame-src 'none';
         object-src 'none';
         base-uri 'self';

--- a/templates/category.ejs
+++ b/templates/category.ejs
@@ -8,6 +8,12 @@
     <link rel="manifest" href="/app.webmanifest">
     <!-- Google tag (gtag.js) for GA4 property G-H0YG3RTJVM -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-H0YG3RTJVM"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-H0YG3RTJVM', { 'send_page_view': true, 'transport_type': 'beacon' });
+    </script>
     <script src="../dist/js/csp.js"></script>
     <title><%= categoryName %> - El Rincón de Ébano</title>
     <link rel="icon" type="image/x-icon" href="../assets/images/web/favicon.ico">

--- a/templates/index.ejs
+++ b/templates/index.ejs
@@ -9,6 +9,12 @@
 
   <!-- Google tag (gtag.js) for GA4 property G-H0YG3RTJVM -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-H0YG3RTJVM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-H0YG3RTJVM', { 'send_page_view': true, 'transport_type': 'beacon' });
+  </script>
 
   <!-- Security -->
   <script src="dist/js/csp.js?v=2" async></script>

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,6 +1,19 @@
 const assert = require('assert');
+const path = require('path');
+const { pathToFileURL } = require('url');
 
-(async () => {
+const analyticsModulePath = path.resolve(__dirname, '../src/js/modules/analytics.mjs');
+const analyticsModuleUrl = pathToFileURL(analyticsModulePath);
+
+async function importAnalyticsModule(tag) {
+  const url = new URL(analyticsModuleUrl.href);
+  if (tag) {
+    url.searchParams.set('scenario', tag);
+  }
+  return import(url.href);
+}
+
+async function runFreshSetupTest() {
   const listeners = [];
   const idleCallbacks = [];
   const timeouts = [];
@@ -63,7 +76,7 @@ const assert = require('assert');
   global.window = windowMock;
   global.document = documentMock;
 
-  const module = await import('../src/js/modules/analytics.mjs');
+  const module = await importAnalyticsModule('fresh');
 
   module.initializeAnalytics();
 
@@ -94,4 +107,114 @@ const assert = require('assert');
 
   delete global.window;
   delete global.document;
-})();
+}
+
+async function runPreconfiguredSetupTest() {
+  const listeners = [];
+  const idleCallbacks = [];
+  const timeouts = [];
+  const appendedScripts = [];
+
+  const existingScript = {
+    dataset: {},
+    listeners: {},
+    addEventListener(event, handler) {
+      this.listeners[event] = handler;
+    }
+  };
+
+  const preconfiguredLayer = [];
+  const gtagStub = function gtag() {
+    preconfiguredLayer.push(arguments);
+  };
+
+  preconfiguredLayer.push(['js', new Date('2024-01-01T00:00:00Z')]);
+  preconfiguredLayer.push(['config', 'G-H0YG3RTJVM', { send_page_view: true, transport_type: 'beacon' }]);
+
+  const documentMock = {
+    visibilityState: 'visible',
+    head: {
+      appendChild(element) {
+        appendedScripts.push(element);
+      }
+    },
+    createElement(tag) {
+      if (tag !== 'script') {
+        throw new Error('Unexpected element requested');
+      }
+
+      return {
+        async: false,
+        dataset: {},
+        listeners: {},
+        set src(value) {
+          this._src = value;
+        },
+        get src() {
+          return this._src;
+        },
+        set nonce(value) {
+          this._nonce = value;
+        },
+        get nonce() {
+          return this._nonce;
+        },
+        addEventListener(event, handler) {
+          this.listeners[event] = handler;
+        }
+      };
+    },
+    querySelector() {
+      return existingScript;
+    }
+  };
+
+  const windowMock = {
+    document: documentMock,
+    dataLayer: preconfiguredLayer,
+    gtag: gtagStub,
+    requestIdleCallback(callback, options) {
+      idleCallbacks.push({ callback, options });
+      return idleCallbacks.length;
+    },
+    setTimeout(callback, delay) {
+      timeouts.push({ callback, delay });
+      return timeouts.length;
+    },
+    addEventListener(event, handler, options) {
+      listeners.push({ event, handler, options });
+    }
+  };
+
+  global.window = windowMock;
+  global.document = documentMock;
+
+  const module = await importAnalyticsModule('preconfigured');
+
+  module.initializeAnalytics();
+
+  assert.strictEqual(windowMock.gtag, gtagStub, 'existing gtag stub should be preserved');
+  assert.strictEqual(windowMock.dataLayer.length, 2, 'preconfigured commands should remain without duplicates');
+  assert.strictEqual(windowMock.__gtagInitialised, true, 'window flag should mark analytics initialised');
+
+  const pointerListener = listeners.find((listener) => listener.event === 'pointerdown');
+  assert.ok(pointerListener, 'pointerdown listener should be registered with preconfigured dataLayer');
+  assert.ok(idleCallbacks.length > 0 || timeouts.length > 0, 'analytics should schedule deferred loader when preconfigured');
+
+  assert.strictEqual(appendedScripts.length, 0, 'gtag script should reuse existing tag without appending');
+
+  const initialLength = windowMock.dataLayer.length;
+  module.initializeAnalytics();
+  assert.strictEqual(windowMock.dataLayer.length, initialLength, 'reinitialisation should not queue extra commands');
+
+  delete global.window;
+  delete global.document;
+}
+
+(async () => {
+  await runFreshSetupTest();
+  await runPreconfiguredSetupTest();
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- embed the GA4 inline initialization snippet in the index and category templates so Google sees the measurement tag in the HTML
- update the analytics module to respect preconfigured dataLayer commands while still loading gtag when needed, and relax the CSP for the inline snippet and jsDelivr source maps
- broaden the analytics tests to cover both fresh and preconfigured setups

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d41d13f3008328b5a625c82eab13ea