### PR TITLE
Allow analytics domains in CSP

### DIFF
--- a/dist/js/csp.js
+++ b/dist/js/csp.js
@@ -36,7 +36,7 @@
         style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com 'nonce-${cspNonce}';
         img-src 'self' data: https:;
         font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net;
-        connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com;
+        connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://cloudflareinsights.com;
         frame-src 'none';
         object-src 'none';
         base-uri 'self';

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js && node test/robots.test.js && node test/analytics.test.js"
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js && node test/robots.test.js && node test/analytics.test.js && node test/csp.connect.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/js/csp.js
+++ b/src/js/csp.js
@@ -36,7 +36,7 @@
         style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com 'nonce-${cspNonce}';
         img-src 'self' data: https:;
         font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net;
-        connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://cdn.jsdelivr.net;
+        connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://cloudflareinsights.com https://cdn.jsdelivr.net;
         frame-src 'none';
         object-src 'none';
         base-uri 'self';

--- a/test/csp.connect.test.js
+++ b/test/csp.connect.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function readPolicy(fileRelativePath) {
+  const filePath = path.resolve(__dirname, '..', fileRelativePath);
+  const content = fs.readFileSync(filePath, 'utf8');
+  const collapsed = content.replace(/\s+/g, ' ');
+  const match = collapsed.match(/connect-src[^;]+;/);
+  assert.ok(match, `connect-src directive must exist in ${fileRelativePath}`);
+  return match[0];
+}
+
+function verifyPolicy(fileRelativePath) {
+  const directive = readPolicy(fileRelativePath);
+  const requiredHosts = [
+    'https://www.google-analytics.com',
+    'https://analytics.google.com',
+    'https://region1.google-analytics.com'
+  ];
+
+  requiredHosts.forEach((host) => {
+    assert.ok(
+      directive.includes(host),
+      `Expected ${host} in connect-src directive for ${fileRelativePath}`
+    );
+  });
+}
+
+verifyPolicy('src/js/csp.js');
+verifyPolicy('dist/js/csp.js');


### PR DESCRIPTION
## Summary
- allow the Content Security Policy to connect to Google Analytics collection endpoints
- add a regression test that verifies the CSP script ships the required Google Analytics hosts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d444abf86c8328831f47436d479057