### PR TITLE
Remove broken skip link from category pages

### DIFF
--- a/pages/aguas.html
+++ b/pages/aguas.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/bebidas.html
+++ b/pages/bebidas.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/carnesyembutidos.html
+++ b/pages/carnesyembutidos.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/cervezas.html
+++ b/pages/cervezas.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/chocolates.html
+++ b/pages/chocolates.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/despensa.html
+++ b/pages/despensa.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/energeticaseisotonicas.html
+++ b/pages/energeticaseisotonicas.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/espumantes.html
+++ b/pages/espumantes.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/juegos.html
+++ b/pages/juegos.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/jugos.html
+++ b/pages/jugos.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/lacteos.html
+++ b/pages/lacteos.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/limpiezayaseo.html
+++ b/pages/limpiezayaseo.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/llaveros.html
+++ b/pages/llaveros.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/mascotas.html
+++ b/pages/mascotas.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/piscos.html
+++ b/pages/piscos.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/snacksdulces.html
+++ b/pages/snacksdulces.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/snackssalados.html
+++ b/pages/snackssalados.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/software.html
+++ b/pages/software.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/pages/vinos.html
+++ b/pages/vinos.html
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <header id="navbar-container" role="banner">
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" aria-label="Navegación principal">
     <div class="container-fluid">

--- a/templates/category.ejs
+++ b/templates/category.ejs
@@ -41,8 +41,6 @@
     <meta property="og:type" content="website">
 </head>
 <body>
-    <a href="#main-content" class="skip-link">Saltar al contenido principal</a>
-
     <%- include('partials/navbar') %>
 
     <main id="main-content" data-category="<%= categoryName %>" role="main" tabindex="-1">


### PR DESCRIPTION
## Summary
- remove the non-functional skip-link anchor from the reusable category template so subcategory pages stop rendering it
- update each generated subcategory HTML page to reflect the template change and eliminate the broken "Saltar al contenido principal" link

## Testing
- npm test *(hangs after reporting success; interrupted)*

📊 COMPLIANCE: 4/7 rules met (Missing: R2 tooling unavailable locally, R3 tests hang, R6 deferred to CI)
🤖 Model: gpt-5-codex-low
🧪 Tests: attempted (`npm test` – interrupted after hang)
🔐 Security: bandit/gitleaks/pip-audit not installed in container (deferred to CI)
⚠️ Failed: R2, R3, R6

------
https://chatgpt.com/codex/tasks/task_e_68eb061a32a0832fb155ce8864bdf0b1