### PR TITLE
Fix Codacy workflow matrix when no SARIF files generated

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -64,7 +64,12 @@ jobs:
           done
       - name: List SARIF files
         id: sarif-list
-        run: echo "files=$(ls results-*.sarif | jq -R -s -c 'split(\"\\n\")[:-1] | to_entries | map({index:.key,file:.value})')" >> "$GITHUB_OUTPUT"
+        run: |
+          files=$(ls results-*.sarif 2>/dev/null | jq -R -s -c 'split(\"\\n\")[:-1] | to_entries | map({index:.key,file:.value})')
+          if [ -z "$files" ] || [ "$files" = "" ]; then
+            files='[]'
+          fi
+          echo "files=${files}" >> "$GITHUB_OUTPUT"
       - name: Upload SARIF artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- ensure the Codacy workflow outputs an empty matrix when no SARIF files are produced so fromJson always parses valid JSON

## Testing
- Not run (workflow configuration change)

📊 COMPLIANCE: 5/7 rules met (Deferred: R3,R6)
🤖 Model: gpt-5-codex-low
🧪 Tests: none (not applicable)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R3,R6

------
https://chatgpt.com/codex/tasks/task_e_68eb17abc47c832f878b2a52d76d1bfb