### PR TITLE
Handle missing SARIF files when listing Codacy SARIF artifacts

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -65,9 +65,12 @@ jobs:
       - name: List SARIF files
         id: sarif-list
         run: |
-          files=$(ls results-*.sarif 2>/dev/null | jq -R -s -c 'split(\"\\n\")[:-1] | to_entries | map({index:.key,file:.value})')
-          if [ -z "$files" ] || [ "$files" = "" ]; then
+          shopt -s nullglob
+          sarif_files=(results-*.sarif)
+          if [ ${#sarif_files[@]} -eq 0 ]; then
             files='[]'
+          else
+            files=$(printf '%s\n' "${sarif_files[@]}" | jq -R -s -c 'split(\"\\n\")[:-1] | to_entries | map({index:.key,file:.value})')
           fi
           echo "files=${files}" >> "$GITHUB_OUTPUT"
       - name: Upload SARIF artifacts


### PR DESCRIPTION
## Summary
- guard the SARIF glob in the Codacy workflow so missing artifacts do not fail the step
- fall back to an empty matrix when no SARIF files are generated

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ebaaab18e0832fa015743d7c257c51