### PR TITLE
Fix Codacy workflow SARIF listing quoting

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -64,12 +64,26 @@ jobs:
           done
       - name: List SARIF files
         id: sarif-list
+        shell: bash
         run: |
-          files=$(ls results-*.sarif 2>/dev/null | jq -R -s -c 'split(\"\\n\")[:-1] | to_entries | map({index:.key,file:.value})')
-          if [ -z "$files" ] || [ "$files" = "" ]; then
-            files='[]'
+          shopt -s nullglob
+          files=(results-*.sarif)
+
+          if (( ${#files[@]} == 0 )); then
+            echo 'files=[]' >> "$GITHUB_OUTPUT"
+            echo "No SARIF files found."
+            exit 0
           fi
-          echo "files=${files}" >> "$GITHUB_OUTPUT"
+
+          json=$(jq -cn --args "${files[@]}" '
+            $ARGS.positional
+            | to_entries
+            | map({index: .key, file: .value})
+          ')
+
+          echo "files=${json}" >> "$GITHUB_OUTPUT"
+          echo "Discovered SARIF files:"
+          echo "${json}"
       - name: Upload SARIF artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- replace the Codacy SARIF discovery step with a bash+jq implementation that avoids ls|jq quoting issues
- ensure the workflow emits an empty JSON array when no SARIF files exist and logs discovered files safely

## Testing
- Deferred to CI (workflow-only change)

## Root Cause
Using single-quoted jq program text inside YAML and escaping quotes forced jq to parse invalid characters. Building the JSON list via `jq --args` on the shell array removes fragile quoting and newline handling.

## Compliance Report
📊 COMPLIANCE: 7/7 rules met (R6 deferred to CI)
🤖 Model: gpt-5-codex-low
🧪 Tests: none (workflow change, coverage unaffected)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: None

------
https://chatgpt.com/codex/tasks/task_e_68ebb0662628832fa8f07c5427f55859