### PR TITLE
fix: validate Codacy SARIF input before splitting

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -65,7 +65,22 @@ jobs:
 
           input="results.sarif"
 
-          if ! jq -e 'has("runs") and (.runs | type == "array") and (.runs | length > 0)' "$input" > /dev/null; then
+          if [[ ! -s "$input" ]]; then
+            echo "Expected SARIF output in $input but the file is missing or empty" >&2
+            exit 1
+          fi
+
+          if ! jq empty "$input" > /dev/null 2>&1; then
+            echo "Failed to parse $input as valid JSON" >&2
+            exit 1
+          fi
+
+          if ! jq -e 'has("runs") and (.runs | type == "array")' "$input" > /dev/null; then
+            echo "SARIF file $input does not contain a valid runs array" >&2
+            exit 1
+          fi
+
+          if jq -e '(.runs | length) == 0' "$input" > /dev/null; then
             echo "No runs found in $input. Nothing to split."
             exit 0
           fi


### PR DESCRIPTION
## Summary
- ensure Codacy SARIF splitting step fails when the expected results file is missing or invalid
- keep zero-run SARIF as a no-op while preserving previous failure behavior for malformed inputs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ebc030e6d4832f97dbe8e6dec0e346