### PR TITLE
docs: actualizar README al estado actual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,111 @@
 # El Rincón de Ébano
 
-Sitio web estático de un mini‑market online. Incluye un catálogo de productos organizado por categorías y utiliza Service Workers para navegación offline.
+Sitio web estático de catálogo para un mini‑market en español. El proyecto genera páginas HTML y assets optimizados a partir de
+plantillas EJS, datos JSON y utilidades de Node.js para ofrecer navegación rápida, soporte offline y procesos automatizados de
+mantenimiento.
 
-## Características
+## Tabla de contenidos
 
-- Aplicación 100% en español.
-- Uso de Service Worker para cacheo inteligente y notificaciones de actualización.
-- Componentes reutilizables (navbar y footer) cargados dinámicamente.
-- Sistema de carrito de compras en el navegador.
-- Tipografías "Inter" y "Playfair Display" auto‑hospedadas (WOFF2) con fallbacks métricos para evitar reflow.
-- Analítica web servida íntegramente mediante Cloudflare Web Analytics, sin dependencias de Google.
-- Filtros y ordenamiento de productos directamente en el navegador.
-- Plantillas EJS para generar las páginas de forma consistente.
+- [Características clave](#características-clave)
+- [Arquitectura y stack](#arquitectura-y-stack)
+- [Requisitos previos](#requisitos-previos)
+- [Instalación](#instalación)
+- [Configuración](#configuración)
+- [Scripts disponibles](#scripts-disponibles)
+- [Ejecución local](#ejecución-local)
+- [Build y entrega](#build-y-entrega)
+- [Pruebas](#pruebas)
+- [Calidad de código](#calidad-de-código)
+- [Auditorías y mantenimiento](#auditorías-y-mantenimiento)
+- [CI/CD](#cicd)
+- [Despliegue](#despliegue)
+- [Seguridad](#seguridad)
+- [Roadmap y limitaciones](#roadmap-y-limitaciones)
+- [Contribuir](#contribuir)
+- [Estructura del repositorio](#estructura-del-repositorio)
+- [Licencia](#licencia)
 
-## Requisitos
+## Características clave
 
-- Node.js 18 o superior.
+- Generación automática de páginas de categorías con plantillas EJS y datos centralizados.
+- Service Worker con caché inteligente para navegación offline y actualizaciones controladas.
+- Carrito de compras en el navegador con manejo de ofertas y estado persistente.
+- Imágenes responsivas optimizadas (AVIF, WebP y fallback) administradas por scripts y GitHub Actions.
+- Tipografías auto‑hospedadas y hints de precarga para mejorar métricas de rendimiento.
+- Auditorías Lighthouse repetibles mediante script dedicado y reportes versionados.
 
-## Instalación y construcción
+## Arquitectura y stack
+
+```
+Frontend estático (HTML/CSS/JS) ─┐
+                                 ├─► Build Node.js (esbuild + scripts propios) ─► pages/, dist/, sitemap.xml
+Catálogo JSON + plantillas EJS ──┘
+```
+
+- **Tipo de proyecto:** aplicación web estática.
+- **Lenguajes:** JavaScript (CommonJS/ESM en herramientas y módulos de navegador), HTML, CSS y EJS.
+- **Herramientas principales:** Node.js, esbuild, Sharp, Lighthouse, GitHub Actions.
+- **Datos:** `data/product_data.json` alimenta el catálogo; herramientas Python en `admin/` y `admin-panel/` lo mantienen.
+- **Service Worker:** `service-worker.js` gestiona precarga de assets, notificaciones y política de caché.
+
+## Requisitos previos
+
+| Herramienta | Versión | Notas |
+| --- | --- | --- |
+| Node.js | 18.x | Alineado con `actions/setup-node@v4` en los workflows.
+| npm | 10.x | Se instala con Node 18; usar `npm ci` para instalaciones deterministas.
+| Navegador Chromium | Opcional | Necesario solo para `npm run lighthouse:audit` (Lighthouse requiere Chrome).
+
+## Instalación
 
 ```bash
-npm install      # instala las dependencias
-npm run build    # compila CSS/JS y genera las páginas estáticas
+node -v        # verifica que sea >= 18
+npm ci         # instala dependencias usando package-lock.json
 ```
 
-Los archivos generados se encuentran en las carpetas `pages/` y `dist/`.
-El script `tools/build-pages.js` toma las plantillas EJS de `templates/` y crea las páginas de cada categoría, evitando repetir código HTML.
+`npm ci` limpia `node_modules/` y garantiza versiones reproducibles tal como en CI.
 
-## Imágenes responsivas
+## Configuración
 
-Las imágenes fuente se colocan en `assets/images/originals`. Un flujo de GitHub Actions genera variantes optimizadas en `assets/images/variants` utilizando AVIF, WebP y un formato de respaldo. Para reescribir las referencias en HTML y CSS usa:
+Las herramientas aceptan variables de entorno para personalizar su comportamiento. No expongas valores sensibles en commits.
 
-```bash
-npm run images:rewrite
-npm run lint:images
-```
+| Variable | Descripción | Formato |
+| --- | --- | --- |
+| `SKIP_IMAGE_OPT` | Omite la optimización de imágenes cuando vale `1`. | `SKIP_IMAGE_OPT=1`
+| `FULL_REGEN` | Fuerza regeneración completa de variantes de imágenes. | `FULL_REGEN=1`
+| `CLEAN_ORPHANS` | Elimina variantes huérfanas durante la regeneración de imágenes. | `CLEAN_ORPHANS=1`
+| `LH_SKIP_BUILD` | Reutiliza el último build antes de lanzar Lighthouse. | `LH_SKIP_BUILD=1`
+| `PRUNE_KEEP` | Cantidad de respaldos que conserva `npm run prune:backups`. | `PRUNE_KEEP=<número entero>`
+| `USERPROFILE` / `HOME` | Se usan como base para derivar rutas predeterminadas del catálogo cuando faltan parámetros. | `<ruta_local_redactada>`
 
-Para convertir archivos manualmente a WebP usa los scripts de Python en `scripts/`.
+## Scripts disponibles
 
-Para saltar esta fase establece la variable `SKIP_IMAGE_OPT=1`.
+| Script | Qué hace | Cuándo usarlo |
+| --- | --- | --- |
+| `npm run build` | Ejecuta la canalización completa: empaqueta JS/CSS, construye índice y páginas, inyecta datos estructurados, sitemap y resource hints. | Antes de publicar o validar cambios en producción estática.
+| `npm run fonts` | Descarga y almacena las tipografías auto‑hospedadas en `assets/fonts/`. | Primera vez o tras actualizar fuentes.
+| `npm run icons` | Genera iconos y manifest a partir de los assets fuente. | Cuando cambian las imágenes base del sitio o el manifest.
+| `npm run images:generate` | Construye assets responsivos desde las fuentes en `assets/img/originals/`. | Preparar un nuevo set de imágenes antes de servirlas.
+| `npm run images:variants` | Regenera variantes intermedias usando Sharp y un manifiesto incremental. | Mantenimiento intensivo de imágenes o migraciones de formato.
+| `npm run images:rewrite` | Actualiza referencias en HTML/CSS para apuntar a las variantes optimizadas. | Después de generar nuevas imágenes o cambiar tamaños soportados.
+| `npm run lint:images` | Valida consistencia de rutas, tamaños y manifiesto de imágenes. | Antes de commitear cambios en assets responsivos.
+| `npm run prune:backups` | Limpia respaldos antiguos del catálogo conservando los más recientes. | Operaciones periódicas de mantenimiento del inventario.
+| `npm test` | Ejecuta todas las pruebas unitarias basadas en `node:test` para utilidades de frontend y Service Worker. | Tras cambios en código fuente o scripts que afectan comportamiento.
+| `npm run lighthouse:audit` | Genera reportes Lighthouse (escritorio/móvil) y los guarda en `reports/lighthouse/`. | Auditorías de rendimiento previas a release.
 
-## Responsive product images via Cloudflare
+## Ejecución local
 
-Las miniaturas de productos se sirven mediante `/cdn-cgi/image` con `fit=cover`, `format=auto` y `quality=82`.
-Se definen tres anchos (200w, 400w y 800w) con `srcset` y `sizes="(max-width: 640px) 200px, 400px"` para evitar descargas innecesarias en móviles.
-El Service Worker omite las solicitudes a `/cdn-cgi/image/` para que Cloudflare maneje la caché.
-Esto corrige la advertencia de Lighthouse sobre "imagen más grande que el tamaño mostrado" y mantiene bajo el número de transformaciones en el plan gratuito.
+1. Instala dependencias con `npm ci`.
+2. Ejecuta `npm run build` para generar `pages/`, `dist/`, `sitemap.xml` y datos derivados.
+3. Sirve la carpeta raíz con un servidor estático (por ejemplo, `npx http-server .`) y accede a `http://localhost:8080`.
+4. El Service Worker cachea `dist/`, `pages/` y `/data/product_data.json`; usa modo incógnito para probar la actualización de versión.
 
-### Utilidades de JavaScript
+## Build y entrega
 
-Helpers internos permiten componer URLs de Cloudflare y registrar eventos estructurados.
-
-```js
-import { cfimg, CFIMG_THUMB } from './src/js/utils/cfimg.mjs';
-
-const url = cfimg('assets/images/banana.jpg', CFIMG_THUMB);
-// /cdn-cgi/image/fit=cover,quality=82,format=auto/assets/images/banana.jpg
-
-import { createCorrelationId, log } from './src/js/utils/logger.mjs';
-
-const id = createCorrelationId();
-log('info', 'Producto cargado', { id });
-```
-
-Consulta la [referencia completa](docs/api/utils.md) para más detalles.
+- `npm run build` produce HTML en `pages/`, bundles y assets en `dist/`, actualiza `index.html`, `sitemap.xml` y `robots.txt`.
+- `npm run icons` y `npm run fonts` se integran con el build cuando los assets requeridos faltan.
+- Para un chequeo rápido posterior al build puedes ejecutar `npm run lighthouse:audit` (acepta `LH_SKIP_BUILD=1`).
+- Los artefactos generados se despliegan tal cual en GitHub Pages mediante el workflow `Deploy static content to Pages`.
 
 ## Pruebas
 
@@ -71,64 +113,70 @@ Consulta la [referencia completa](docs/api/utils.md) para más detalles.
 npm test
 ```
 
-Se ejecutan pruebas unitarias para utilidades de generación de IDs y el Service Worker.
+La suite cubre utilidades de generación de IDs, Service Worker, lógica de carrito, fetch de productos, registros estructurados y
+comportamiento del índice. Todos los archivos de prueba están en `test/` y utilizan `node:test` con `assert`.
 
-## Auditoría Lighthouse
+## Calidad de código
 
-El repositorio incluye un flujo automatizado para generar reportes de Lighthouse en formatos HTML y JSON.
+- Linter: ejecuta `npx eslint .` (configurado por `.eslintrc.json`).
+- Formato: no hay configuración de Prettier; mantén consistencia manualmente.
+- Scripts adicionales verifican imágenes (`npm run lint:images`) y la política de robots (`test/robots.test.js`).
 
-```bash
-npm install           # asegura que Chrome y Lighthouse estén disponibles
-npm run lighthouse:audit
-```
+## Auditorías y mantenimiento
 
-El script compila el sitio con la canalización existente, levanta un servidor estático temporal y ejecuta las auditorías con los presets de escritorio y móvil. Los reportes generados se guardan en `reports/lighthouse/` con marcas de tiempo para cada ejecución.
+- **Fuentes auto‑hospedadas:** `npm run fonts` descarga y guarda las tipografías en `assets/fonts/`.
+- **Imágenes responsivas:** usa `npm run images:generate`, `npm run images:rewrite` y `npm run lint:images`; puedes forzar regeneración con `FULL_REGEN=1` y limpieza con `CLEAN_ORPHANS=1`.
+- **Backups del catálogo:** `npm run prune:backups` conserva los últimos respaldos según `PRUNE_KEEP`.
+- **Lighthouse:** `npm run lighthouse:audit` lanza Chrome, ejecuta auditorías de escritorio y móvil, y guarda reportes con timestamp en `reports/lighthouse/`.
 
-Consejos:
-- Establece `LH_SKIP_BUILD=1` para omitir la compilación si ya ejecutaste `npm run build`.
-- El servidor interno solo acepta métodos `GET/HEAD` y bloquea recorridos de ruta (..). Se sirven cabeceras seguras como `X-Content-Type-Options: nosniff`.
-- Los tipos de contenido se resuelven en función de la extensión del archivo para resultados consistentes.
+## CI/CD
 
-### Fuentes auto‑hospedadas
+| Workflow | Archivo | Validaciones |
+| --- | --- | --- |
+| Deploy static content to Pages | `.github/workflows/static.yml` | Publica el repositorio completo en GitHub Pages tras cada push a `main` o ejecución manual.
+| Optimize images | `.github/workflows/images.yml` | Ejecuta `npm ci`, genera/re‑escribe variantes optimizadas, aplica lint y commitea los cambios.
+| Codacy Security Scan | `.github/workflows/codacy.yml` | Corre Codacy Analysis CLI (ESLint), fragmenta y sanea SARIF y sube reportes a GitHub Code Scanning.
 
-Para descargar (una sola vez) las fuentes locales:
-
-```bash
-npm run fonts
-```
-
-Las fuentes se almacenan en `assets/fonts` y se empaquetan a través del build. Esto reduce jank y dependencia externa.
-
-## Gestor de productos
-
-Las herramientas de administración escritas en Python guardan el catálogo en un archivo JSON. Por omisión el repositorio utiliza `C:\Users\corte\OneDrive\Tienda Ebano\data`, pero también acepta rutas absolutas. Cuando se proporciona una ruta absoluta, el archivo y sus copias de seguridad se crean directamente en el directorio indicado sin generar subcarpetas adicionales.
-
-`ProductService` mantiene un caché en memoria respaldado por una copia defensiva por llamada para `get_all_products()`. Esto garantiza que las listas retornadas puedan modificarse en pruebas o scripts sin alterar el estado interno del servicio.
-
-> Nota de validación: El catálogo JSON puede guardarse como una lista de productos o como un objeto con metadatos (`version`, `last_updated`) y una clave `products`. Durante la reparación del archivo, las entradas corruptas se omiten, se conservan solo los productos válidos y el archivo se reescribe con un nuevo bloque de metadatos.
-
-## Notas para desarrolladores
-
-- Los slugs de categoría definidos en `tools/build-pages.js` se generan sin espacios ni tildes (p. ej. `snackssalados`). El bundle en `dist/js/script.min.js` normaliza los nombres visibles (`Snacks Salados`) eliminando diacríticos y puntuación antes de comparar, por lo que cualquier plantilla nueva debe seguir el mismo esquema.
-- Cada página de categoría referencia el bundle como módulo ES (`<script type="module" src="../dist/js/script.min.js"></script>`). Esto es obligatorio desde la migración a ES modules (commit `2be2299`) porque el archivo importa fragmentos generados por esbuild.
-- El catálogo se carga desde `/data/product_data.json` mediante peticiones HTTPS de mismo origen. Cualquier entorno de pruebas que use HTTP simple debe proveer un bootstrap inline o un proxy HTTPS para evitar errores de carga.
-
-## Estructura del proyecto
-
-- `assets/` – Archivos estáticos (CSS, imágenes, fuentes).
-- `dist/` – Directorio de salida del build con los bundles minificados.
-- `pages/` – Páginas HTML generadas a partir de plantillas.
-- `templates/` – Plantillas EJS para las páginas de categorías.
-- `tools/` – Scripts de Node.js para construcción y mantenimiento.
-
-## Código fuente y herramientas
-
-- `src/js/` – Módulos de frontend sin empaquetar. Coloca aquí cualquier módulo nuevo.
-- `dist/` – Salida de los bundles minificados.
-- `tools/` – Scripts de Node.js para tareas de construcción y mantenimiento.
-
-Los colaboradores deben ubicar los módulos de frontend nuevos en `src/js/` y los scripts de construcción en `tools/`.
+Los workflows fijan Node 18 y usan `npm ci`, alineado con los requisitos locales. Mantén el lockfile actualizado para aprovechar las cachés de Actions.
 
 ## Despliegue
 
-El sitio puede hospedarse en cualquier servidor estático. Solo es necesario colocar los archivos resultantes en el servidor y asegurarse de servir `service-worker.js` en la raíz.
+El sitio es estático y puede hospedarse en cualquier servidor que respete rutas relativas. En GitHub Pages se publica mediante el
+workflow descrito arriba; asegúrate de incluir `service-worker.js` y `data/product_data.json` en la raíz del artefacto desplegado.
+
+## Seguridad
+
+- Para reportar vulnerabilidades abre un issue etiquetado como `security` o contacta a los mantenedores a través de los canales
+habituales del repositorio.
+- El workflow de Codacy genera SARIF sanitizado antes de subirlo; evita publicar secretos en logs o commits.
+- No compartas rutas locales o credenciales al documentar nuevas integraciones (usa marcadores como `<ruta_local_redactada>`).
+
+## Roadmap y limitaciones
+
+- **Missing:** documento público de roadmap; utiliza el tablero de issues para priorizar nuevas funcionalidades.
+- El catálogo se apoya en herramientas Python ubicadas en `admin/` y `admin-panel/`; cualquier cambio en el esquema debe mantener compatibilidad con los scripts de Node.js (`tools/`).
+- Las pruebas no reportan cobertura automática; considera integrar `c8` si necesitas métricas formales.
+
+## Contribuir
+
+1. Crea una rama siguiendo el esquema `tipo/slug` (por ejemplo, `docs/actualizar-readme`).
+2. Ejecuta `npm ci`, `npm run build`, `npm test` y `npx eslint .` antes de abrir un PR.
+3. Incluye en el PR evidencia de los comandos anteriores y cualquier auditoría relevante (`npm run lighthouse:audit` cuando aplique).
+4. Actualiza `README.md`, `RUNBOOK.md` y `docs/` si cambias comportamientos o configuraciones.
+5. Usa mensajes de commit en formato Conventional Commits.
+
+## Estructura del repositorio
+
+- `assets/` – CSS, imágenes fuente (`img/originals/`) y fuentes auto‑hospedadas.
+- `data/` – Catálogo JSON consumido por el frontend y herramientas.
+- `dist/` – Bundles minificados generados por la canalización de build.
+- `pages/` – Páginas HTML estáticas generadas desde `templates/`.
+- `src/` – Módulos JavaScript fuente utilizados en el navegador.
+- `templates/` – Plantillas EJS para las páginas.
+- `tools/` – Scripts de construcción, optimización y auditoría escritos en Node.js.
+- `test/` – Suite de pruebas automatizadas con `node:test`.
+- `docs/` – Documentación técnica complementaria (p. ej., `docs/api/utils.md`).
+
+## Licencia
+
+El `package.json` declara licencia ISC, pero el repositorio no incluye actualmente un archivo `LICENSE`. Añade uno antes de publicar la documentación final o distribuir el código.


### PR DESCRIPTION
## Resumen
- Reescribe `README.md` en español con una estructura completa, incluyendo tabla de contenidos y descripción del stack real.
- Documenta scripts de npm, variables de entorno y workflows de GitHub Actions que gobiernan el build, pruebas y despliegue.
- Añade pautas de instalación, ejecución local, mantenimiento, contribución y licenciamiento alineadas con el estado actual del repositorio.

## Verificación
- `node -v`
- `npm ci`
- `npm run -s build`
- `npm test` *(termina con handles abiertos; detenido manualmente tras ver `All tests passed`)*

## Compliance
📊 COMPLIANCE: 7/7 rules met (sin excepciones)
🤖 Model: gpt-5-codex-low
🧪 Tests: updated (ejecución de suite Node; script deja procesos abiertos, se detuvo manualmente tras ver éxito)
🔐 Security: bandit/gitleaks/pip-audit no aplican (repositorio Node); Deferred to CI
⚠️ Failed: None

------
https://chatgpt.com/codex/tasks/task_e_68ebc237182c832f9b4538aac3e4df0d