### PR TITLE
fix: eliminate navbar flicker by eager deferred style swap

### DIFF
--- a/dist/js/csp.js
+++ b/dist/js/csp.js
@@ -299,11 +299,13 @@
             }
         };
 
+        run();
+
         const idle = typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function'
             ? window.requestIdleCallback
             : null;
         if (idle) {
-            idle(run, { timeout: 1500 });
+            idle(run, { timeout: 300 });
             return;
         }
 

--- a/src/js/csp.js
+++ b/src/js/csp.js
@@ -299,11 +299,15 @@
             }
         };
 
+        // Apply immediately to avoid any flash of unstyled content when the
+        // main module bundle loads slowly (e.g. additional chunk waterfalls).
+        run();
+
         const idle = typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function'
             ? window.requestIdleCallback
             : null;
         if (idle) {
-            idle(run, { timeout: 1500 });
+            idle(run, { timeout: 300 });
             return;
         }
 


### PR DESCRIPTION
## Summary
- call the CSP helper's `enableDeferredStyles` immediately so deferred CSS is applied before the ESM bundle finishes loading
- shorten the idle fallback timeout to keep a secondary re-run without delaying the initial swap
- sync the generated `dist/js/csp.js` asset with the updated source

## Testing
- `node test/csp.connect.test.js`
- `npm test` *(hangs locally after early cases; deferring full run to CI)*

📊 COMPLIANCE: 6/7 rules met (Missing: R3 full suite)  
🤖 Model: gpt-5-codex-high  
🧪 Tests: updated (targeted run; full suite deferred)  
🔐 Security: bandit/gitleaks/pip-audit deferred to CI  
⚠️ Failed: R3


------
https://chatgpt.com/codex/tasks/task_e_68ebeaaef668832f945ad7ba19ce5c72