### PR TITLE
feat: add tagged snapshot tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Las herramientas aceptan variables de entorno para personalizar su comportamient
 | `npm test` | Ejecuta todas las pruebas unitarias basadas en `node:test` para utilidades de frontend y Service Worker. | Tras cambios en código fuente o scripts que afectan comportamiento.
 | `npm run check:css-order` | Verifica que los entrypoints HTML carguen `critical → Bootstrap → site` sin `media=print` ni cambios de orden. | Siempre que se modifiquen plantillas o el `<head>`.
 | `npm run test:e2e` | Lanza Playwright contra Home y dos categorías para detectar parpadeos del navbar/cart bajo condiciones móviles lentas. | Después de tocar estilos globales o la navegación.
-| `npm run lighthouse:audit` | Genera reportes Lighthouse (escritorio/móvil) y los guarda en `reports/lighthouse/`. | Auditorías de rendimiento previas a release.
+| `npm run lighthouse:audit` | Genera reportes Lighthouse (escritorio/móvil) y los guarda en `reports/lighthouse/`. | Auditorías de rendimiento previas a release. |
+| `npm run snapshot -- --tag <etiqueta>` | Toma una captura del sitio en ejecución y la etiqueta con un identificador para su trazabilidad. | Documentar estados visuales relevantes o generar evidencia previa a un release. |
 
 ## Ejecución local
 
@@ -108,6 +109,24 @@ Las herramientas aceptan variables de entorno para personalizar su comportamient
 - `npm run icons` y `npm run fonts` se integran con el build cuando los assets requeridos faltan.
 - Para un chequeo rápido posterior al build puedes ejecutar `npm run lighthouse:audit` (acepta `LH_SKIP_BUILD=1`).
 - Los artefactos generados se despliegan tal cual en GitHub Pages mediante el workflow `Deploy static content to Pages`.
+
+### Snapshots etiquetados
+
+El script `tools/snapshot-site.mjs` automatiza la toma de capturas del sitio en ejecución (sirve la carpeta raíz con tu servidor estático favorito). Guarda los archivos dentro de `reports/snapshots/` y mantiene un `manifest.json` ordenado por fecha más reciente. Los parámetros disponibles son:
+
+| Parámetro | Tipo | Requerido | Predeterminado | Descripción |
+| --- | --- | --- | --- | --- |
+| `--tag` | string | Sí | N/A | Identificador humano legible que se sanitiza antes de usarse en los nombres de archivo. |
+| `--url` | string | No | `http://127.0.0.1:8080/` | URL que se abrirá en Chromium para capturar el snapshot (debe estar sirviendo el sitio). |
+| `--outdir` | string | No | `reports/snapshots` | Carpeta donde se guardarán la captura y el `manifest.json`. |
+
+Ejemplo:
+
+```bash
+npm run snapshot -- --tag staging -- --url http://localhost:4173/
+```
+
+Cada ejecución añade una entrada al manifiesto con el tag, URL, nombre de archivo relativo y la hora de captura, lo que facilita referenciar visualmente los estados del sitio.
 
 ## Pruebas
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js && node test/resourceHints.integrity.test.js && node test/robots.test.js && node test/csp.connect.test.js",
+    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js && node test/resourceHints.integrity.test.js && node test/robots.test.js && node test/csp.connect.test.js && node test/snapshot.utils.test.mjs",
     "test:e2e": "playwright test",
-    "lighthouse:audit": "node tools/lighthouse-audit.mjs"
+    "lighthouse:audit": "node tools/lighthouse-audit.mjs",
+    "snapshot": "node tools/snapshot-site.mjs --tag dev"
   },
   "keywords": [],
   "author": "",

--- a/reports/snapshots/README.md
+++ b/reports/snapshots/README.md
@@ -1,0 +1,10 @@
+# Snapshots etiquetados
+
+Este directorio almacena capturas de pantalla generadas por `tools/snapshot-site.mjs`. Cada archivo PNG sigue el patrón `snapshot-<tag>-<timestamp>.png` y el manifiesto `manifest.json` mantiene un historial ordenado (entrada más reciente primero) con los metadatos:
+
+- `tag`: identificador sanitizado usado para agrupar el snapshot.
+- `url`: origen que se visitó al capturar la imagen.
+- `file`: ruta relativa al repositorio donde quedó guardada la captura.
+- `capturedAt`: marca temporal ISO‑8601 de cuando se generó la evidencia.
+
+Sube únicamente archivos generados por el script para conservar consistencia.

--- a/test/snapshot.utils.test.mjs
+++ b/test/snapshot.utils.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { sanitizeTag, appendSnapshotMetadata } from '../tools/snapshot-site.mjs';
+
+const TMP_PREFIX = 'snapshot-utils-test-';
+
+async function createTempManifestPath() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), TMP_PREFIX));
+  return path.join(tempDir, 'manifest.json');
+}
+
+test('sanitizeTag normalises whitespace and removes diacritics', () => {
+  const result = sanitizeTag('  Álbum Promoción 2025  ');
+  assert.equal(result, 'album-promocion-2025');
+});
+
+test('sanitizeTag enforces minimum length', () => {
+  assert.throws(() => sanitizeTag('   '), /tag cannot be empty/);
+  assert.throws(() => sanitizeTag('***'), /sanitisation removed all characters/);
+});
+
+test('sanitizeTag truncates very long strings', () => {
+  const longTag = 'a'.repeat(200);
+  const result = sanitizeTag(longTag);
+  assert.equal(result.length, 64);
+});
+
+test('appendSnapshotMetadata appends entries and keeps them sorted', async () => {
+  const manifestPath = await createTempManifestPath();
+  const firstEntry = {
+    tag: 'baseline',
+    url: 'http://localhost:8080/',
+    file: 'reports/snapshots/snapshot-baseline.png',
+    capturedAt: '2024-01-01T00:00:00.000Z',
+  };
+  const latestEntry = {
+    tag: 'release',
+    url: 'http://localhost:8080/',
+    file: 'reports/snapshots/snapshot-release.png',
+    capturedAt: '2025-01-01T00:00:00.000Z',
+  };
+
+  await appendSnapshotMetadata(manifestPath, firstEntry);
+  await appendSnapshotMetadata(manifestPath, latestEntry);
+
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  assert.deepEqual(manifest.snapshots.map((entry) => entry.tag), ['release', 'baseline']);
+});

--- a/tools/snapshot-site.mjs
+++ b/tools/snapshot-site.mjs
@@ -1,0 +1,177 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '@playwright/test';
+
+const DEFAULT_OUTPUT_DIR = path.resolve(process.cwd(), 'reports', 'snapshots');
+const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
+
+/**
+ * Sanitize a human provided tag so it can be used inside file names.
+ * @param {string} rawTag - The user provided tag to sanitise.
+ * @returns {string} a safe, lowercased identifier suitable for filenames.
+ */
+export function sanitizeTag(rawTag) {
+  if (typeof rawTag !== 'string') {
+    throw new TypeError('tag must be a string');
+  }
+
+  const trimmed = rawTag.trim();
+  if (!trimmed) {
+    throw new Error('tag cannot be empty');
+  }
+
+  const normalised = trimmed.normalize('NFKD');
+  const cleaned = normalised
+    .replace(/[^\p{Letter}\p{Number}\s_-]+/gu, '')
+    .replace(/\s+/g, '-');
+  const collapsed = cleaned.replace(/-+/g, '-').replace(/_+/g, '_');
+  const result = collapsed.toLowerCase().replace(/^[-_]+|[-_]+$/g, '');
+
+  if (!result) {
+    throw new Error('tag sanitisation removed all characters');
+  }
+
+  if (result.length > 64) {
+    return result.slice(0, 64);
+  }
+
+  return result;
+}
+
+/**
+ * Ensure that the snapshot output directory exists.
+ * @param {string} targetDir - Absolute path to the output directory.
+ */
+export async function ensureDirectory(targetDir) {
+  await mkdir(targetDir, { recursive: true });
+}
+
+/**
+ * Append a snapshot entry to the manifest file in a deterministic way.
+ * @param {string} manifestPath - Path to the JSON manifest file.
+ * @param {object} entry - Snapshot entry to record.
+ */
+export async function appendSnapshotMetadata(manifestPath, entry) {
+  let data = { snapshots: [] };
+
+  try {
+    const file = await readFile(manifestPath, 'utf8');
+    const parsed = JSON.parse(file);
+    if (Array.isArray(parsed.snapshots)) {
+      data = parsed;
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  data.snapshots.push(entry);
+  data.snapshots.sort((a, b) => new Date(b.capturedAt) - new Date(a.capturedAt));
+
+  await writeFile(manifestPath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+/**
+ * Capture a snapshot of the provided URL and persist a manifest entry.
+ * @param {object} options - Snapshot configuration options.
+ * @param {string} options.baseUrl - URL to capture.
+ * @param {string} options.tag - Sanitised tag used for naming.
+ * @param {string} [options.outputDir] - Directory where artifacts will live.
+ * @returns {Promise<object>} snapshot metadata.
+ */
+export async function captureSnapshot({ baseUrl, tag, outputDir = DEFAULT_OUTPUT_DIR }) {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const fileName = `snapshot-${tag}-${timestamp}.png`;
+  const manifestName = 'manifest.json';
+  const filePath = path.join(outputDir, fileName);
+  const manifestPath = path.join(outputDir, manifestName);
+
+  await ensureDirectory(outputDir);
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.setViewportSize(DEFAULT_VIEWPORT);
+    await page.goto(baseUrl, { waitUntil: 'networkidle' });
+    await page.screenshot({ path: filePath, fullPage: true });
+  } finally {
+    await browser.close();
+  }
+
+  const entry = {
+    tag,
+    url: baseUrl,
+    file: path.relative(process.cwd(), filePath).split(path.sep).join('/'),
+    capturedAt: new Date().toISOString(),
+  };
+
+  await appendSnapshotMetadata(manifestPath, entry);
+  return entry;
+}
+
+async function runCli() {
+  const { values } = parseArgs({
+    options: {
+      tag: {
+        type: 'string',
+      },
+      url: {
+        type: 'string',
+        default: 'http://127.0.0.1:8080/',
+      },
+      outdir: {
+        type: 'string',
+      },
+    },
+    allowPositionals: true,
+  });
+
+  if (!values.tag) {
+    throw new Error('Missing required option --tag');
+  }
+
+  const sanitized = sanitizeTag(values.tag);
+  const targetDir = values.outdir
+    ? path.resolve(process.cwd(), values.outdir)
+    : DEFAULT_OUTPUT_DIR;
+
+  let targetUrl;
+  try {
+    targetUrl = new URL(values.url);
+  } catch {
+    throw new Error('Invalid --url parameter, expected an absolute URL');
+  }
+
+  const entry = await captureSnapshot({
+    baseUrl: targetUrl.toString(),
+    tag: sanitized,
+    outputDir: targetDir,
+  });
+
+  console.info(
+    JSON.stringify({
+      level: 'info',
+      message: 'snapshot-created',
+      snapshot: entry,
+    })
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runCli().catch((error) => {
+    console.error(
+      JSON.stringify({
+        level: 'error',
+        message: 'snapshot-failed',
+        error: {
+          name: error.name,
+          message: error.message,
+        },
+      })
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a Playwright-powered CLI (`tools/snapshot-site.mjs`) to capture tagged website snapshots and record them in a manifest
- cover tag sanitisation and manifest sorting with focused node:test cases and wire the utility into npm scripts
- document the workflow in README plus a scoped README for `reports/snapshots/`

## Testing
- npm test

## Security
- bandit -ll -r . *(deferred: tool unavailable in container)*
- gitleaks detect *(deferred: tool unavailable in container)*
- pip-audit *(deferred: tool unavailable in container)*

📊 COMPLIANCE: 5/7 rules met (missing R2, R6 – external tooling unavailable / ESLint migration pending)
🤖 Model: gpt-5-codex-medium
🧪 Tests: created (snapshot utils); coverage summary N/A (instrumentation missing)
🔐 Security: bandit/gitleaks/pip-audit deferred – binaries not present in container
⚠️ Failed: R2, R6

------
https://chatgpt.com/codex/tasks/task_e_68ebf52ef6b4832fa21eb5b3c9b2fdab