### PR TITLE
Fix dropdown state machine regressions in navbar

### DIFF
--- a/tests/navbar-dropdown.spec.ts
+++ b/tests/navbar-dropdown.spec.ts
@@ -49,6 +49,7 @@ for (const path of paths) {
 
     await expect(toggle).toBeVisible();
     await toggle.click();
+    await page.waitForTimeout(100);
     await expect(menu).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-expanded', /true/i);
 
@@ -94,5 +95,10 @@ for (const path of paths) {
     await firstToggle.click();
     await expect(firstMenu).toBeVisible();
     await expect(secondMenu).not.toBeVisible();
+    await secondToggle.click();
+    await firstToggle.click();
+    await secondToggle.click();
+    await expect(secondMenu).toBeVisible();
+    await expect(secondToggle).toHaveAttribute('aria-expanded', /true/i);
   });
 }


### PR DESCRIPTION
## Summary
- replace the dropdown lazy-loader with a controlled state machine that tracks expanded ids, reuses Bootstrap instances, and cleans up listeners to avoid deadlocks
- add regression-focused unit coverage for the Bootstrap module plus stronger Playwright expectations to catch first-click auto-close and rapid toggling failures

## Root Cause
- commit 07d312d introduced an eager call to `Dropdown.clearMenus(event)` while also removing the toggle's click listener after the first interaction. Because propagation was stopped, Bootstrap's delegated handlers never saw later clicks and the manual clear closed new menus immediately, leaving subsequent toggles unresponsive.

## Testing
- `node test/bootstrap.module.test.js`
- `npm run test:e2e` *(fails locally: Playwright browsers are not installed in the container)*

## Repro Notes
- Reproduce categories freeze by hard-refreshing `/index.html`, opening one dropdown, then immediately switching to a different one. Prior to this fix the second menu would not open until another reload.
- On a subcategory page (e.g. `/pages/energeticaseisotonicas.html`), the first dropdown interaction previously closed itself instantly; the new state tracker keeps it open.

## Video/GIF
- TODO (not recorded in this environment)

📊 COMPLIANCE: 6/7 rules met (R6 pending ESLint config & Playwright browser download)
🤖 Model: gpt-5-codex-medium
🧪 Tests: created + updated; bootstrap module unit coverage now asserts controlled ids
🔐 Security: bandit/gitleaks/pip-audit not run locally (unchanged deps)
⚠️ Failed: R6 (eslint config missing & Playwright binaries unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68ed26a06c68832f800354989a7d0fa7