### PR TITLE
fix: adopt node 20 in CI and polyfill tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - run: npm run images:generate
       - run: npm run images:rewrite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+### Changed
+- Migrated CI workflows to Node.js 20 LTS and documented the new baseline.
+- Added a test bootstrap (`test/setup-globals.js`) that polyfills Web APIs such as
+  `File` when running unit tests on Node 18, keeping local development unblocked.

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Catálogo JSON + plantillas EJS ──┘
 
 | Herramienta | Versión | Notas |
 | --- | --- | --- |
-| Node.js | 18.x | Alineado con `actions/setup-node@v4` en los workflows.
-| npm | 10.x | Se instala con Node 18; usar `npm ci` para instalaciones deterministas.
+| Node.js | 20.x (recomendado) | LTS actual en CI. `>=18.17` funciona para desarrollo/test gracias al bootstrap de Web APIs.
+| npm | 10.x | Se instala con Node 20; usar `npm ci` para instalaciones deterministas.
 | Navegador Chromium | Opcional | Necesario solo para `npm run lighthouse:audit` (Lighthouse requiere Chrome).
 
 ## Instalación
 
 ```bash
-node -v        # verifica que sea >= 18
+node -v        # verifica que sea >= 18.17 (20.x recomendado)
 npm ci         # instala dependencias usando package-lock.json
 ```
 
@@ -156,6 +156,10 @@ npm run test:e2e
 npm run test:cypress
 ```
 
+> Nota: El runner `npm test` precarga `test/setup-globals.js` para instalar
+> `fetch`, `File` y APIs asociadas cuando se ejecute con Node 18, manteniendo
+> paridad con el entorno de CI en Node 20.
+
 La suite de `node:test` cubre utilidades de generación de IDs, Service Worker, lógica de carrito, fetch de productos, registros estructurados y
 comportamiento del índice. Los nuevos chequeos aseguran el orden determinista de CSS y que navbar/cart no parpadeen (Playwright bajo viewport móvil, ver `tests/`). La suite Cypress documenta y previene las regresiones CAT-01/SUB-01 del menú principal y puede automatizarse vía `./.git-bisect-test.sh`.
 
@@ -181,7 +185,7 @@ comportamiento del índice. Los nuevos chequeos aseguran el orden determinista d
 | Optimize images | `.github/workflows/images.yml` | Ejecuta `npm ci`, genera/re‑escribe variantes optimizadas, aplica lint y commitea los cambios.
 | Codacy Security Scan | `.github/workflows/codacy.yml` | Corre Codacy Analysis CLI (ESLint), fragmenta y sanea SARIF y sube reportes a GitHub Code Scanning.
 
-Los workflows fijan Node 18 y usan `npm ci`, alineado con los requisitos locales. Mantén el lockfile actualizado para aprovechar las cachés de Actions.
+Los workflows fijan Node 20 y usan `npm ci`, alineado con los requisitos locales. Mantén el lockfile actualizado para aprovechar las cachés de Actions.
 
 ## Despliegue
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "images:rewrite": "node tools/rewrite-images.mjs",
     "lint:images": "node tools/lint-images.mjs",
     "prune:backups": "node tools/prune-backups.js",
-    "test": "node test/generateStableId.test.js && node test/serviceWorker.utils.test.js && node test/registerServiceWorker.test.js && node test/fetchProducts.test.js && node test/updateProductDisplay.test.js && node test/cart.test.js && node test/ensureDiscountToggle.test.js && node test/memoize.test.js && node test/notifications.test.js && node test/swCache.test.js && node test/modules.dom.test.js && node test/fetchWithRetry.test.js && node test/bootstrap.module.test.js && node test/menu-controller.test.js && node test/initAppFallback.test.js && node test/buildIndex.lcp.test.js && node test/resourceHints.integrity.test.js && node test/robots.test.js && node test/csp.connect.test.js && node test/performance.metrics.test.js && node test/snapshot.utils.test.mjs",
+    "test": "node test/run-all.js",
     "test:cypress": "cypress run --spec cypress/e2e/nav_menu.cy.ts",
     "test:e2e": "playwright test --trace on",
     "lighthouse:audit": "node tools/lighthouse-audit.mjs",
@@ -41,5 +41,8 @@
     "@popperjs/core": "^2.11.8",
     "bootstrap": "^5.3.3",
     "ejs": "^3.1.10"
+  },
+  "engines": {
+    "node": ">=18.17.0 <23"
   }
 }

--- a/test/run-all.js
+++ b/test/run-all.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+require('./setup-globals');
+
+const tests = [
+  'generateStableId.test.js',
+  'serviceWorker.utils.test.js',
+  'registerServiceWorker.test.js',
+  'fetchProducts.test.js',
+  'updateProductDisplay.test.js',
+  'cart.test.js',
+  'ensureDiscountToggle.test.js',
+  'memoize.test.js',
+  'notifications.test.js',
+  'swCache.test.js',
+  'modules.dom.test.js',
+  'fetchWithRetry.test.js',
+  'bootstrap.module.test.js',
+  'menu-controller.test.js',
+  'initAppFallback.test.js',
+  'buildIndex.lcp.test.js',
+  'resourceHints.integrity.test.js',
+  'robots.test.js',
+  'csp.connect.test.js',
+  'performance.metrics.test.js',
+  'snapshot.utils.test.mjs',
+];
+
+for (const testFile of tests) {
+  const testPath = path.join(__dirname, testFile);
+  const result = spawnSync(process.execPath, [testPath], {
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    throw new Error(`Test ${testFile} exited with code ${result.status}`);
+  }
+}

--- a/test/setup-globals.js
+++ b/test/setup-globals.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * Test-only bootstrap that fills in missing fetch/Web API globals when running
+ * under Node.js versions that do not yet expose them by default (e.g. Node 18).
+ *
+ * The shim only installs each global if it is absent to preserve the runtime's
+ * native implementations on modern Node LTS releases.
+ */
+try {
+  const {
+    fetch,
+    Headers,
+    Request,
+    Response,
+    FormData,
+    File,
+    Blob,
+  } = require('undici');
+
+  const globalsToInstall = {
+    fetch,
+    Headers,
+    Request,
+    Response,
+    FormData,
+    File,
+    Blob,
+  };
+
+  for (const [name, implementation] of Object.entries(globalsToInstall)) {
+    if (!globalThis[name] && implementation) {
+      Object.defineProperty(globalThis, name, {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: implementation,
+      });
+    }
+  }
+} catch (error) {
+  process.emitWarning(
+    `Failed to set up Web API test shims: ${error.message}`,
+    {
+      code: 'TEST_WEB_API_SHIM',
+      detail: error.stack,
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- switch the CI and image optimization workflows to Node.js 20 LTS to align with the new runtime baseline
- add a test bootstrap that polyfills File/fetch-related globals via undici and run the suite through a centralized runner
- document the Node 20 recommendation, updated test flow, and record the transition in the changelog

## Testing
- npm test

📊 COMPLIANCE: 8/9 rules met (Deferred: R6 lint/security tooling)
🤖 Model: gpt-5-codex-medium
✅ Backwards Compat: compatible
🧪 Tests: updated (`npm test`)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R6 (Deferred lint/security tooling)
📝 Commit: fix(ci): use node20 with test shims
🔄 Deferred to CI: npx eslint . (missing new config), bandit, gitleaks, pip-audit

------
https://chatgpt.com/codex/tasks/task_e_68ee32dd5848832fa0769e80289aeba0