### PR TITLE
Allow duplicate product names when descriptions differ

### DIFF
--- a/admin/product_manager/models.py
+++ b/admin/product_manager/models.py
@@ -59,6 +59,38 @@ class Product:
         if not isinstance(self.field_last_modified, dict):
             self.field_last_modified = {}
 
+    @staticmethod
+    def _normalize_text(value: Any) -> str:
+        """Return a canonical lowercase representation collapsing whitespace."""
+
+        if not isinstance(value, str):
+            return ""
+        collapsed = " ".join(value.split())
+        return collapsed.casefold()
+
+    @classmethod
+    def normalized_name(cls, name: str) -> str:
+        """Normalize a product name for comparisons."""
+
+        return cls._normalize_text(name)
+
+    @classmethod
+    def normalized_description(cls, description: str) -> str:
+        """Normalize a product description for comparisons."""
+
+        return cls._normalize_text(description)
+
+    @classmethod
+    def identity_key_from_values(cls, name: str, description: str) -> str:
+        """Build the canonical identity key for the provided values."""
+
+        return f"{cls.normalized_name(name)}::{cls.normalized_description(description)}"
+
+    def identity_key(self) -> str:
+        """Return the canonical identity key for the current product."""
+
+        return self.identity_key_from_values(self.name, self.description)
+
     def _validate_name(self) -> None:
         """Validate product name."""
         if not isinstance(self.name, str):
@@ -255,11 +287,11 @@ class Product:
         """Check if two products are equal."""
         if not isinstance(other, Product):
             return NotImplemented
-        return self.name.lower() == other.name.lower()
+        return self.identity_key() == other.identity_key()
 
     def __hash__(self) -> int:
-        """Hash based on the product name."""
-        return hash(self.name.lower())
+        """Hash based on the canonical product identity."""
+        return hash(self.identity_key())
 
 @dataclass
 class ProductMetadata:

--- a/admin/product_manager/tests/test_product_service_duplicates.py
+++ b/admin/product_manager/tests/test_product_service_duplicates.py
@@ -1,0 +1,116 @@
+import sys
+import types
+from pathlib import Path
+from typing import List
+
+import pytest
+
+
+if 'portalocker' not in sys.modules:
+  portalocker_stub = types.ModuleType('portalocker')
+  portalocker_stub.LOCK_EX = 0
+  portalocker_stub.LOCK_SH = 0
+
+  def _noop(*_args, **_kwargs) -> None:
+    return None
+
+  portalocker_stub.lock = _noop
+  portalocker_stub.unlock = _noop
+  sys.modules['portalocker'] = portalocker_stub
+
+ROOT_PATH = Path(__file__).resolve().parents[3]
+if str(ROOT_PATH) not in sys.path:
+  sys.path.insert(0, str(ROOT_PATH))
+
+MODULE_PATH = Path(__file__).resolve().parents[1]
+if str(MODULE_PATH) not in sys.path:
+  sys.path.insert(0, str(MODULE_PATH))
+
+from admin.product_manager.models import Product
+from admin.product_manager.services import (
+  DuplicateProductError,
+  ProductService,
+  ProductServiceError,
+)
+from admin.product_manager.repositories import ProductRepositoryProtocol
+
+
+class InMemoryRepository(ProductRepositoryProtocol):
+  """Simple in-memory repository used for service tests."""
+
+  def __init__(self, products: List[Product]):
+    self._products = list(products)
+
+  def load_products(self) -> List[Product]:
+    return list(self._products)
+
+  def save_products(self, products: List[Product]) -> None:
+    self._products = list(products)
+
+
+def test_add_product_allows_duplicate_name_with_unique_description() -> None:
+  repo = InMemoryRepository([
+      Product(name='Producto', description='Original', price=1000)
+  ])
+  service = ProductService(repo)
+
+  duplicate_name = Product(name='Producto', description='Variante', price=1200)
+  service.add_product(duplicate_name)
+
+  products = service.get_all_products()
+  assert len(products) == 2
+  assert {p.description for p in products} == {'Original', 'Variante'}
+
+
+def test_add_product_rejects_exact_identity_duplicate() -> None:
+  repo = InMemoryRepository([
+      Product(name='Producto', description='Original', price=1000)
+  ])
+  service = ProductService(repo)
+  duplicate_identity = Product(name='Producto', description='Original', price=1200)
+
+  with pytest.raises(DuplicateProductError):
+    service.add_product(duplicate_identity)
+
+
+def test_get_product_by_name_requires_description_with_duplicates() -> None:
+  repo = InMemoryRepository([
+      Product(name='Producto', description='Original', price=1000),
+      Product(name='Producto', description='Variante', price=900),
+  ])
+  service = ProductService(repo)
+
+  with pytest.raises(ProductServiceError):
+    service.get_product_by_name('Producto')
+
+  selected = service.get_product_by_name('Producto', 'Variante')
+  assert selected.price == 900
+
+
+def test_update_product_with_duplicate_name_uses_description() -> None:
+  base = Product(name='Producto', description='Original', price=1000)
+  repo = InMemoryRepository([
+      base,
+      Product(name='Producto', description='Variante', price=900),
+  ])
+  service = ProductService(repo)
+
+  updated = Product(name='Producto', description='Original', price=1500)
+  service.update_product(base.name, updated, base.description)
+
+  refreshed = service.get_product_by_name('Producto', 'Original')
+  assert refreshed.price == 1500
+
+
+def test_delete_product_with_duplicate_name_removes_exact_match() -> None:
+  repo = InMemoryRepository([
+      Product(name='Producto', description='Original', price=1000),
+      Product(name='Producto', description='Variante', price=900),
+  ])
+  service = ProductService(repo)
+
+  removed = service.delete_product('Producto', 'Variante')
+  assert removed is True
+  remaining = service.get_all_products()
+  assert len(remaining) == 1
+  assert remaining[0].description == 'Original'


### PR DESCRIPTION
## Summary
- normalize product identity to the name+description combination so Content Manager can store variants that only differ in their copy while still blocking exact duplicates
- update Content Manager interactions (row lookup, edits, deletes, bulk actions) to pass descriptions for disambiguation when duplicate names exist
- add regression tests covering duplicate-name scenarios across add/update/delete flows

## Testing
- pytest admin/product_manager/tests -q

📊 COMPLIANCE: 7/9 (R2 security scans deferred; R6 frontend lint/build deferred)
🤖 Model: gpt-5-codex-medium
✅ Backwards Compat: compatible
🧪 Tests: created (pytest); coverage not measured
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R2,R6
📝 Commit: fix(content-manager): allow duplicate product names
🔄 Deferred to CI: bandit, gitleaks, pip-audit, npx eslint ., npm test, npm run build


------
https://chatgpt.com/codex/tasks/task_e_68f3bd61e050832f8f0f7ef2d12cfab1