### PR TITLE
docs(pricing): clarify pricing and discount rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ flowchart TD
 
 _No environment variables are required for the default build. Optional flags such as `FULL_REGEN` or `LH_SKIP_BUILD` fine-tune heavy scripts and are documented inline in `tools/`._
 
+## Pricing & Discounts
+
+- **Currency:** prices are stored and rendered in Chilean pesos (CLP).
+- **Discount semantics:** `discount` is an absolute CLP amount (not a percentage), subtracted from `price`.
+- **Display rules:** when discounted, the UI shows the discounted price as primary and the original price struck through; otherwise it shows the base price only.
+
+Example (CLP amounts, absolute discount):
+
+```json
+{
+  "price": 5000,
+  "discount": 1000
+}
+```
+
+This yields a displayed final price of `CLP 4.000`, with the original `CLP 5.000` struck through and a derived `20%` badge.
+
 ### Product image workflow (WebP + AVIF)
 
 - Every catalog entry still needs a traditional fallback image (`image_path`) in `assets/images/` using one of the existing extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`).

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -31,3 +31,8 @@
 - **Configuración:** `sync.enabled` se mantiene en `false` y `sync.api_base` vacío (`admin/product_manager/content_manager.py:44-69`).
 - **Ejecución:** abre la app → realiza ediciones → guarda. Los cambios quedan en el archivo del repo y se suben vía commit/push.
 - **Sincronización remota opcional:** habilítala sólo si hay un backend disponible. Crea un override (`config.json`) con `sync.enabled: true` y `sync.api_base` apuntando al endpoint. Mientras no haya backend, deja esos valores en blanco para evitar colas pendientes.
+
+## Nota de esquema de datos (price/discount)
+
+- `price`: entero en CLP, representa el precio base del producto.
+- `discount`: entero en CLP, representa un descuento absoluto que se resta a `price` para calcular el precio final mostrado.


### PR DESCRIPTION
### Motivation
- Clarify how product pricing is represented so build scripts, templates and the admin UI agree on currency and discount semantics.
- Prevent accidental misinterpretation of `discount` as a percentage by documenting that it is an absolute CLP amount.
- Provide a concrete example in the README to align contributor edits and the offline Content Manager with the displayed UI.
- Assumption: examples use Chilean pesos (CLP) and a period as thousands separator in human-facing examples for readability.

### Description
- Added a `Pricing & Discounts` section to `README.md` stating that values are in `CLP`, that `discount` is an absolute amount, and describing display rules.
- Inserted a `Nota de esquema de datos (price/discount)` in `docs/operations/RUNBOOK.md` documenting that `price` and `discount` are integer CLP values and how final price is calculated.
- Included a JSON example in `README.md` that demonstrates `price`/`discount` as absolute CLP values and a note about the derived percentage badge.
- Changes are documentation-only and committed on branch `docs/pricing-discounts` with the commit message `docs(pricing): clarify price and discount rules`.

### Testing
- No automated tests were executed because this is a documentation-only change and functional checks are deferred to CI.
- Deferred automated checks: `npx eslint .`, `npm run format`, `npm test`, `npm run build`, and `npm audit --production` to be run in CI.
- CI is expected to validate that templates and JS continue to render prices correctly and that there are no regressions when the full suite runs.
- Compliance: documentation changes kept small to stay within the PR change budget and preserve backwards compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aeb6f2514832f96cb4943782a7252)