### PR TITLE
docs(availability): document stock availability behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Example (CLP amounts, absolute discount):
 
 This yields a displayed final price of `CLP 4.000`, with the original `CLP 5.000` struck through and a derived `20%` badge.
 
+## Availability
+
+- **Stock flag:** set `stock: false` in `data/product_data.json` to mark a product as unavailable.
+- **Visual treatment:** the card receives the `agotado` class, which applies a dark overlay
+  badge labeled **"AGOTADO"** and grayscales the product image (`assets/css/style.css`,
+  `assets/css/style-enhanced.css`).
+- **Catalog filtering:** client-side filtering/search excludes out-of-stock items, so
+  filtered views hide products with `stock: false` even though the base catalog can still
+  render them.
+
 ### Product image workflow (WebP + AVIF)
 
 - Every catalog entry still needs a traditional fallback image (`image_path`) in `assets/images/` using one of the existing extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`).

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -36,3 +36,11 @@
 
 - `price`: entero en CLP, representa el precio base del producto.
 - `discount`: entero en CLP, representa un descuento absoluto que se resta a `price` para calcular el precio final mostrado.
+
+## Nota operativa de stock
+
+- `stock` debe mantenerse explícito en cada producto (`true` o `false`) al actualizar `data/product_data.json`.
+- Usa `stock: false` para productos sin disponibilidad temporal: el catálogo los marca
+  como **AGOTADO** y aplica escala de grises; además, los filtros del frontend los
+  ocultan.
+- Evita borrar productos por falta de stock; conserva el registro para reactivarlo cuando vuelva disponibilidad.


### PR DESCRIPTION
### Motivation

- Clarify how the UI surfaces product availability so maintainers know how to mark items unavailable in data and what the site will render. 
- Capture the existing rendering semantics (badge, grayscale, CSS class) so operational edits to `data/product_data.json` are predictable. 
- Add an operational note to the runbook so content managers set `stock` consistently and avoid accidental deletions. 

### Description

- Added an `Availability` section to `README.md` documenting that setting `stock: false` in `data/product_data.json` marks a product unavailable and that the card receives the `agotado` class. 
- Documented the visual treatment that includes an **"AGOTADO"** overlay badge and image desaturation implemented in `assets/css/style.css` and `assets/css/style-enhanced.css`. 
- Added `docs/operations/RUNBOOK.md` guidance titled `Nota operativa de stock` describing expectations for maintaining `stock` (`true`/`false`) and advising to keep product records rather than deleting them. 
- Changes touch only documentation files: `README.md` and `docs/operations/RUNBOOK.md` and reflect current template/JS behavior that already applies the `agotado` class and filters out unavailable items client-side. 

### Testing

- No automated tests were run locally; validation is deferred to CI and should include `npm test`, `npx eslint .`, `npm run format`, and `npm audit --production`. 
- The change was committed on branch `docs/availability-notes` with the commit message `docs(availability): document stock rendering`. 
- Assumption: the CI pipeline will execute the lint/test/audit checks listed above and confirm no regressions; these checks are currently deferred to CI. 
- Manual verification performed by scanning templates/CSS/JS to ensure the documented `agotado` class and filtering behavior match the code paths referenced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aecfde6e0832fb36c460f51f1dd3a)