### PR TITLE
docs(readme): add category taxonomy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,34 @@ flowchart TD
 
 _No environment variables are required for the default build. Optional flags such as `FULL_REGEN` or `LH_SKIP_BUILD` fine-tune heavy scripts and are documented inline in `tools/`._
 
+## Category Taxonomy
+
+Canonical product categories (authoritative list: `data/product_data.json`):
+
+- Aguas
+- Bebidas
+- Carnesyembutidos
+- Cervezas
+- Chocolates
+- Despensa
+- Energeticaseisotonicas
+- Espumantes
+- Juegos
+- Jugos
+- Lacteos
+- Limpiezayaseo
+- Llaveros
+- Mascotas
+- Piscos
+- SnacksDulces
+- SnacksSalados
+- Vinos
+
+**Rules**
+
+- Keep the exact casing and spacing from `data/product_data.json` (no spaces; TitleCase tokens).
+- New categories must be added to `data/product_data.json` and may require corresponding asset paths plus navigation/template updates if the UI exposes category menus.
+
 ## Pricing & Discounts
 
 - **Currency:** prices are stored and rendered in Chilean pesos (CLP).


### PR DESCRIPTION
### Motivation

- Provide a canonical, discoverable list of product categories in `README.md` so contributors know the authoritative source for categories.
- Make it explicit how categories must be cased/spaced and surface the operational impact of adding a category (assets/templates/navigation may need updates).
- Assume `data/product_data.json` is the single source of truth for category tokens and that UI menus/templates consume these exact tokens.

### Description

- Added a new `Category Taxonomy` section to `README.md` that lists categories extracted from `data/product_data.json`.
- Added rules that require keeping the exact casing/spacing from `data/product_data.json` and that new categories must be added there first.
- Documented that adding categories may require corresponding asset paths and template/navigation updates and referenced the authoritative path `data/product_data.json`.

### Testing

- This is a documentation-only change, so no automated unit or integration tests were run and verification is deferred to CI.
- Linting/formatting and build/test/audit steps (`npx eslint .`, `npm run format`, `npm test`, `npm run build`, `npm audit --production`) are deferred to CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aedfecf2c832f97c4bd2b6aa468ff)