### PR TITLE
docs(readme): document language behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ flowchart TD
 
 _No environment variables are required for the default build. Optional flags such as `FULL_REGEN` or `LH_SKIP_BUILD` fine-tune heavy scripts and are documented inline in `tools/`._
 
+## Language behavior
+
+- **Supported languages today:** Spanish-only content is shipped. Any bilingual support is
+  **aspirational** and should not be treated as a guaranteed feature yet.
+- **Default language:** Spanish (`es`) is the default for rendered pages (see `lang="es"` in
+  `templates/index.ejs` and `templates/category.ejs`).
+- **Fallback rules:** there is no runtime language negotiation. If future translations are
+  added, the expected fallback remains Spanish.
+- **Where strings live:** localized copy currently lives directly in EJS templates
+  (`templates/`) and product/category labels in `data/product_data.json`.
+
 ## Category Taxonomy
 
 Canonical product categories (authoritative list: `data/product_data.json`):


### PR DESCRIPTION
### Motivation

- Clarify the repository's language support to avoid implying full bilingual runtime localization.
- Make it explicit where localized strings live so contributors know which files to update.
- Mark bilingual support as aspirational so users do not expect a guaranteed i18n feature yet.
- Assumption: no runtime localization system exists beyond static Spanish strings in `templates/` and `data/product_data.json`.

### Description

- Added a new `Language behavior` section to `README.md` that states supported languages, default language, and fallback rules.
- Referenced `templates/index.ejs`, `templates/category.ejs`, and `data/product_data.json` as the current locations for localized copy and labels.
- Explicitly labeled bilingual support as aspirational and noted there is no runtime language negotiation today.
- This is a documentation-only change limited to `README.md`.

### Testing

- No automated tests were run locally because this is a docs-only change and functional checks are deferred to CI.
- Linting and formatting (`npx eslint .`, `npm run format`) were not executed locally and are deferred to CI.
- Build and test commands (`npm run build`, `npm test`) were not executed locally and are deferred to CI.
- Security audit (`npm audit --production`) was not executed locally and is deferred to CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aee8aafdc832f8b501c0f67a67190)