### PR TITLE
docs(schema): add size normalization schema and Content Manager requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,38 @@ Example (CLP amounts, absolute discount):
 
 This yields a displayed final price of `CLP 4.000`, with the original `CLP 5.000` struck through and a derived `20%` badge.
 
+## Size normalization (product data)
+
+To keep catalog sizing consistent across the site and Content Manager exports, products
+carry normalized size fields. Normalize source strings like `1Kg` or `1 L` to base units.
+
+**Base units by category**
+
+| Category group (data/product_data.json) | Base unit |
+| --------------------------------------- | --------- |
+| Aguas, Bebidas, Cervezas, Jugos, Piscos, Vinos, Espumantes, Energeticaseisotonicas | `ml` |
+| Carnesyembutidos, Chocolates, Despensa, Lacteos, SnacksDulces, SnacksSalados | `g` |
+| Juegos, Llaveros, Mascotas, Limpiezayaseo | `unit` |
+
+**Minimal size schema**
+
+| Name | Type | Default | Required | Description |
+| ---- | ---- | ------- | -------- | ----------- |
+| `size_value` | number | `null` | ✅ | Numeric amount expressed in the base unit for the product category. |
+| `size_unit` | string | `null` | ✅ | Normalized unit: `g`, `ml`, or `unit`. |
+| `size_display` | string | `null` | ❌ | Optional human-readable label (e.g., `1Kg`, `2 x 350 ml`). |
+
+**Normalization examples**
+
+- `1Kg` → `size_value: 1000`, `size_unit: "g"`, `size_display: "1Kg"`.
+- `1 L` → `size_value: 1000`, `size_unit: "ml"`, `size_display: "1 L"`.
+- `Pack x2` → `size_value: 2`, `size_unit: "unit"`, `size_display: "Pack x2"`.
+
+**Display rule**
+
+- If `size_display` is present, render it as-is.
+- Otherwise render `${size_value} ${size_unit}` using the normalized fields.
+
 ## Availability
 
 - **Stock flag:** set `stock: false` in `data/product_data.json` to mark a product as unavailable.

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -53,11 +53,41 @@
 - **Configuración:** `sync.enabled` se mantiene en `false` y `sync.api_base` vacío (`admin/product_manager/content_manager.py:44-69`).
 - **Ejecución:** abre la app → realiza ediciones → guarda. Los cambios quedan en el archivo del repo y se suben vía commit/push.
 - **Sincronización remota opcional:** habilítala sólo si hay un backend disponible. Crea un override (`config.json`) con `sync.enabled: true` y `sync.api_base` apuntando al endpoint. Mientras no haya backend, deja esos valores en blanco para evitar colas pendientes.
+- **Campos normalizados obligatorios (size):**
+  - Completa siempre `size_value` y `size_unit` en cada producto.
+  - Usa unidades normalizadas (`g`, `ml`, `unit`) y convierte el input original:
+    - `1Kg` → `size_value: 1000`, `size_unit: "g"`.
+    - `1 L` → `size_value: 1000`, `size_unit: "ml"`.
+  - Si el producto es por unidades (p. ej. Llaveros), registra el conteo en `size_value`
+    y usa `size_unit: "unit"`.
+  - `size_display` es opcional; úsalo para conservar el string original si ayuda a ventas.
 
 ## Nota de esquema de datos (price/discount)
 
 - `price`: entero en CLP, representa el precio base del producto.
 - `discount`: entero en CLP, representa un descuento absoluto que se resta a `price` para calcular el precio final mostrado.
+
+## Nota de esquema de datos (size)
+
+**Unidades base por categoría**
+
+- `ml`: Aguas, Bebidas, Cervezas, Jugos, Piscos, Vinos, Espumantes, Energeticaseisotonicas.
+- `g`: Carnesyembutidos, Chocolates, Despensa, Lacteos, SnacksDulces, SnacksSalados.
+- `unit`: Juegos, Llaveros, Mascotas, Limpiezayaseo.
+
+**Schema mínimo**
+
+| Name | Type | Default | Required | Description |
+| ---- | ---- | ------- | -------- | ----------- |
+| `size_value` | number | `null` | ✅ | Cantidad numérica en la unidad base de la categoría. |
+| `size_unit` | string | `null` | ✅ | Unidad normalizada (`g`, `ml`, `unit`). |
+| `size_display` | string | `null` | ❌ | Etiqueta opcional para mostrar el formato original. |
+
+**Regla de display**
+
+- Si existe `size_display`, mostrarla tal cual.
+- Si no existe, renderizar `${size_value} ${size_unit}` desde los campos normalizados.
+
 
 ## Nota operativa de stock
 


### PR DESCRIPTION
### Motivation
- Provide a single, minimal schema so product sizes are represented consistently across the catalog and Content Manager.
- Normalize common source strings (e.g., `1Kg`, `1 L`) to canonical base units to simplify rendering, filtering and comparisons.
- Define a clear display fallback so UIs render `size_display` when present and otherwise build a label from normalized fields.
- Assumption: this is a documentation-first change and no code changes were made; validation and enforcement are intended to run in CI or follow-up PRs.

### Description
- Add a "Size normalization (product data)" section to `README.md` describing base units by category, minimal schema (`size_value`, `size_unit`, `size_display`), examples, and the display rule.
- Update `docs/operations/RUNBOOK.md` to require `size_value` and `size_unit` in the Content Manager and include conversion examples and category-to-base-unit mapping.
- Changed files: `README.md` and `docs/operations/RUNBOOK.md`.
- Commit message used: `docs(schema): document size normalization`.

### Testing
- Automated tests were not executed because this is a docs-only change and verification is deferred to CI.
- Lint/format checks (`npx eslint .`, `npm run format`) were not run locally and are deferred to CI.
- Security audit (`npm audit --production`) was not run locally and is deferred to CI.
- The change was committed locally via `git commit` and is ready for PR review and CI validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af36e4f68832fbe965cb3bcf97d6c)