### PR TITLE
docs(readme): clarify CLP pricing, rounding, locale and discount display

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,11 @@ Canonical product categories (authoritative list: `data/product_data.json`):
 ## Pricing & Discounts
 
 - **Currency:** prices are stored and rendered in Chilean pesos (CLP).
-- **Discount semantics:** `discount` is an absolute CLP amount (not a percentage), subtracted from `price`.
-- **Display rules:** when discounted, the UI shows the discounted price as primary and the original price struck through; otherwise it shows the base price only.
+- **Integer vs decimals:** prices and discounts are integers only (no decimals); any intermediate math must end as a whole CLP value.
+- **Rounding rule:** when calculations produce fractional values, round half up to 0 decimals before display/storage.
+- **Locale formatting:** use Chilean formatting (thousands separator `.` and decimal symbol `,`), displayed as `CLP 4.000`.
+- **Discount semantics:** `discount` is an absolute CLP amount (not a percentage) subtracted from `price`.
+- **Discount display impact:** when discounted, show the final price as primary and the original price struck through, plus a derived percentage badge; otherwise show the base price only.
 
 Example (CLP amounts, absolute discount):
 


### PR DESCRIPTION
### Motivation
- Remove ambiguity about currency and price representation in the catalog by documenting a single canonical rule set.
- Ensure all consumers (UI, Content Manager, exports) treat prices and discounts consistently as CLP integer values.
- Provide a deterministic rounding rule to avoid display/storage inconsistencies after arithmetic.
- Standardize locale formatting and discount display so rendered pages and badges are uniform.

### Description
- Updated `README.md` to declare currency as Chilean pesos (CLP) and state that `price` and `discount` are integer CLP amounts only.
- Added a rounding rule: round half up to 0 decimals for any fractional intermediate results before display or storage.
- Specified Chilean locale formatting using `.` as thousands separator and `,` as decimal symbol with an example shown as `CLP 4.000`.
- Clarified discount semantics as absolute CLP amounts subtracted from `price` and that discounted display shows final price primary, original struck-through, and a derived percentage badge; commit message was `docs(readme): clarify pricing rules` on branch `docs/pricing-rules`.

### Testing
- No automated tests were run for this docs-only change; CI will run `npm ci && npm test`, `npm run build`, and `npx eslint .` after push (deferred to CI).
- Lint/format and security scans are deferred to CI and must be green before merge according to repository guardrails.
- If CI reports regressions or policy violations, follow the rollback guidance with `git revert <sha>` as documented in the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af5bf19d0832f8d3bef7361d85157)