### PR TITLE
docs(runbook): add cache bump guidance and verification steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,32 @@ Providing a bilingual-friendly grocery catalog that ships as a static site, pre-
 > // Versioned prefixes make cache busting explicit, avoiding stale assets after data refreshes.
 > ```
 
+### Cache versioning guide
+
+Use explicit cache prefix bumps to force refreshes in the service worker. The
+prefixes live in `service-worker.js` under `CACHE_CONFIG.prefixes`.
+
+**Cache prefix configuration**
+
+| Name | Type | Default | Required | Description |
+| ---- | ---- | ------- | -------- | ----------- |
+| `prefixes.static` | string | `ebano-static-v6` | ✅ | Precached assets such as CSS, JS, icons, fonts, and offline pages. |
+| `prefixes.dynamic` | string | `ebano-dynamic-v4` | ✅ | Runtime cache for HTML fetches and dynamic endpoints outside precache. |
+| `prefixes.products` | string | `ebano-products-v5` | ✅ | Product data cache (JSON) and catalog refresh logic. |
+
+**When to bump**
+
+- **ebano-static:** changes to CSS/JS bundles, icon sets, offline pages, or any
+  precached assets list.
+- **ebano-dynamic:** cache strategy changes or new runtime endpoints.
+- **ebano-products:** data schema changes, catalog invalidation logic, or data
+  refreshes that must bypass old JSON.
+
+**Examples**
+
+- Data changes (prices, stock, product list) → bump `ebano-products`.
+- CSS/JS changes (new styles, UI scripts) → bump `ebano-static`.
+
 ## Tech Stack
 
 - **Runtime:** Node.js 22.x (Volta + `.nvmrc` guardrails). Admin Tools run on Python 3.12.

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -35,6 +35,21 @@
     invalidación del SW, o cuando se requiere forzar recarga completa del catálogo.
   - **Regla práctica:** cada release que cambie el SW o assets precacheados debe incrementar el
     prefijo correspondiente para evitar contenido obsoleto.
+  - **Ejemplos rápidos:**
+    - Cambios de datos (precios, stock, nuevos productos) → `ebano-products`.
+    - Cambios de CSS/JS (estilos, scripts, bundles) → `ebano-static`.
+    - Ajustes de estrategia runtime o nuevos endpoints → `ebano-dynamic`.
+- **Paso a paso: bump y verificación**
+  1. Edita `service-worker.js` y actualiza el prefijo correspondiente en
+     `CACHE_CONFIG.prefixes` (incremento de versión).
+  2. Ejecuta `npm run build` para regenerar el snapshot estático.
+  3. Publica los cambios (commit + deploy).
+  4. En un navegador limpio o incógnito, visita el sitio y abre DevTools →
+     Application → Service Workers.
+  5. Verifica que el SW activo muestre el nuevo prefijo y que los caches nuevos
+     existan en Cache Storage.
+  6. Recarga con hard refresh (`Ctrl+Shift+R`) y confirma que los assets/JSON
+     se sirven desde los nuevos caches.
 - **Invalidar cachés antiguas:**
   1. Abre DevTools → Application → Service Workers.
   2. Ejecuta en la consola:


### PR DESCRIPTION
### Motivation

- Make cache-prefix bumps explicit so maintainers know when to bump `ebano-static`, `ebano-dynamic`, or `ebano-products` to avoid stale client caches.
- Provide concrete examples linking types of changes to the correct cache prefix to reduce accidental stale content after deploys.
- Add a short step-by-step verification to the runbook so operators can confirm the SW and Cache Storage updated correctly after a bump.
- Assumed these are documentation-only changes and do not require code or build changes in this PR.

### Description

- Added a `Cache versioning guide` section to `README.md` that documents `CACHE_CONFIG.prefixes` and the three cache prefix names. 
- Updated `docs/operations/RUNBOOK.md` to include quick examples mapping changes to `ebano-products`, `ebano-static`, and `ebano-dynamic` and added a 6-step "bump and verification" checklist.
- Files changed: `README.md` (new  cache versioning table and examples) and `docs/operations/RUNBOOK.md` (examples + step-by-step verification); total ~41 insertions across both files.
- Diff summary: insert new guidance blocks under the service-worker / cache sections in the two docs to clarify when to bump each prefix.

### Testing

- Automated tests were not run because this is a docs-only change and does not affect runtime code. 
- Lint/format/test steps deferred to CI: `npx eslint .`, `npm run format`, `npm test`, and `npm run build` are listed as deferred checks. 
- Security scans were deferred to CI (`npm audit --production`).
- No failures; commit created with message `docs(runbook): document cache bump guidance`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1c7bd9cc832f8abbbb726ca52149)