### PR TITLE
docs: clarify product data fetch UX and recovery steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,22 @@ carry normalized size fields. Normalize source strings like `1Kg` or `1 L` to ba
   filtered views hide products with `stock: false` even though the base catalog can still
   render them.
 
+## Catalog data fetch UX policy
+
+When `/data/product_data.json` cannot be fetched, the UI follows a strict fallback order:
+
+1. **Last cached full catalog (preferred):** if the service worker cache has a copy of
+   `product_data.json`, the UI renders the last cached full catalog with no blocking error.
+2. **Inline subset (partial):** if cached data is unavailable but the inline catalog exists,
+   the UI renders only that subset. Missing items are hidden (no placeholders).
+3. **Error state:** if neither cached nor inline data is available, the UI shows the error
+   message:
+   `Error al cargar los productos. Por favor, verifique su conexión a internet e inténtelo de nuevo.`
+   and includes an **"Intentar nuevamente"** retry button.
+
+Operational recovery steps for this policy live in
+[`docs/operations/RUNBOOK.md`](docs/operations/RUNBOOK.md).
+
 ### Product image workflow (WebP + AVIF)
 
 - Every catalog entry still needs a traditional fallback image (`image_path`) in `assets/images/` using one of the existing extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`).


### PR DESCRIPTION
### Motivation

- Define explicit user-facing behavior when `/data/product_data.json` cannot be fetched so UX is deterministic during network or cache incidents.  
- Prefer serving the last full catalog from the service worker cache to avoid blocking users, and fall back to inline subset or an error state when needed.  
- Align operational runbook steps with the UI policy so on-call engineers have clear recovery actions.  
- Assumption: the service worker can and will store/serve a cached copy of `product_data.json`, so the runbook relies on that cache being present for the preferred fallback.

### Description

- Added a new "Catalog data fetch UX policy" section to `README.md` documenting the fallback order (cached full catalog → inline subset → error with retry).  
- Updated `docs/operations/RUNBOOK.md` to replace the previous brief note with explicit expected behaviors, steps to verify the `ebano-products-v*` cache, and concrete recovery steps aligned to the UX policy.  
- Behavior decisions documented include hiding missing items when using the inline partial dataset and showing a localized error message plus retry when no data is available.  
- Files changed: `README.md` and `docs/operations/RUNBOOK.md`.

### Testing

- No automated tests were run locally for this docs change and runtime verifications are deferred to CI (`npm test` deferred).  
- Lint/format checks were deferred to CI (`npx eslint .`, `npm run format` deferred).  
- Security dependency checks were deferred to CI (`npm audit --production` deferred).  
- Manual verification: documentation builds and commit were created successfully (changes committed to branch `docs/product-data-failure-ux`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1d393ab0832f9497cffbaf511f26)