### PR TITLE
hardening(release): rollback sha deploy + http contract guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,11 @@ jobs:
       - name: Check stylesheet order consistency
         run: npm run check:css-order
 
+      - name: Validate Astro HTTP contract
+        run: |
+          npm --prefix astro-poc run build
+          npm --prefix astro-poc run contract:http
+
       - name: Cache Playwright browsers
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v4
         with:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,104 @@
+name: Rollback Pages Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      rollback_ref:
+        description: 'Git ref or SHA to deploy to production'
+        required: true
+        default: ''
+      confirm_rollback:
+        description: 'Safety confirmation phrase (must be ROLLBACK)'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  reject-unconfirmed:
+    if: ${{ inputs.confirm_rollback != 'ROLLBACK' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Require explicit confirmation
+        run: |
+          echo "confirm_rollback must equal ROLLBACK"
+          exit 1
+
+  deploy-rollback:
+    if: ${{ inputs.confirm_rollback == 'ROLLBACK' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout rollback ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          ref: ${{ inputs.rollback_ref }}
+          persist-credentials: false
+
+      - name: Resolve rollback metadata
+        shell: bash
+        run: |
+          echo "ROLLBACK_REF=${{ inputs.rollback_ref }}" >> "$GITHUB_ENV"
+          echo "ROLLBACK_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Set deterministic build environment
+        run: |
+          echo "TZ=UTC" >> $GITHUB_ENV
+          echo "LC_ALL=C.UTF-8" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> $GITHUB_ENV
+          echo "CFIMG_ENABLE=1" >> $GITHUB_ENV
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v4
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            astro-poc/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm ci --prefix astro-poc
+
+      - name: Build Astro storefront
+        run: npm --prefix astro-poc run build
+
+      - name: Validate HTTP contract
+        run: npm --prefix astro-poc run contract:http
+
+      - name: Validate artifact contract
+        run: npm --prefix astro-poc run contract:artifacts
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload rollback artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v3
+        with:
+          path: astro-poc/dist
+
+      - name: Deploy rollback to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+      - name: Write rollback summary
+        shell: bash
+        run: |
+          {
+            echo "## Rollback Deploy"
+            echo ""
+            echo "- Requested ref: ${ROLLBACK_REF}"
+            echo "- Deployed SHA: ${ROLLBACK_SHA}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,6 +11,11 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: 'Optional git ref/SHA to deploy (defaults to current workflow ref HEAD)'
+        required: false
+        default: ''
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -31,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          ref: ${{ inputs.deploy_ref != '' && inputs.deploy_ref || github.sha }}
       - name: Set deterministic build environment
         run: |
           echo "TZ=UTC" >> $GITHUB_ENV
@@ -69,11 +76,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_ref != '' && inputs.deploy_ref || github.event.workflow_run.head_sha || github.sha }}
       - name: Resolve deploy metadata
         shell: bash
         run: |
           echo "DEPLOY_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.deploy_ref }}" ]; then
+            echo "DEPLOY_REQUESTED_REF=${{ inputs.deploy_ref }}" >> "$GITHUB_ENV"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "DEPLOY_REQUESTED_REF=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          else
+            echo "DEPLOY_REQUESTED_REF=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_ENV"
+          fi
       - name: Set deterministic build environment
         run: |
           echo "TZ=UTC" >> $GITHUB_ENV
@@ -110,6 +124,15 @@ jobs:
           name: smoke-evidence-deploy
           path: reports/smoke
           if-no-files-found: error
+      - name: Write deploy summary
+        shell: bash
+        run: |
+          {
+            echo "## Deploy Metadata"
+            echo ""
+            echo "- Requested ref: ${DEPLOY_REQUESTED_REF}"
+            echo "- Deployed SHA: ${DEPLOY_SHA}"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact

--- a/astro-poc/package.json
+++ b/astro-poc/package.json
@@ -7,9 +7,10 @@
   "scripts": {
     "data:sync": "node scripts/sync-data.mjs",
     "assets:validate": "node scripts/validate-asset-contract.mjs",
+    "contract:http": "node scripts/validate-http-contract.mjs",
     "contract:artifacts": "node scripts/validate-artifact-contract.mjs",
     "dev": "npx astro dev",
-    "build": "npm run data:sync && npx astro build && node scripts/postbuild-legacy-pages.mjs && node scripts/postbuild-sitemap.mjs && npm run assets:validate && npm run contract:artifacts",
+    "build": "npm run data:sync && npx astro build && node scripts/postbuild-legacy-pages.mjs && node scripts/postbuild-sitemap.mjs && npm run assets:validate && npm run contract:http && npm run contract:artifacts",
     "preview": "npx astro preview"
   },
   "dependencies": {

--- a/astro-poc/scripts/validate-http-contract.mjs
+++ b/astro-poc/scripts/validate-http-contract.mjs
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const distRoot = path.join(projectRoot, 'dist');
+
+const REQUIRED_HTTP_FILES = [
+  'index.html',
+  '404.html',
+  'bebidas.html',
+  'vinos.html',
+  'e.html',
+  'offline.html',
+  path.join('pages', 'offline.html'),
+];
+
+function main() {
+  if (!fs.existsSync(distRoot)) {
+    throw new Error(`Missing dist directory: ${distRoot}`);
+  }
+
+  const missing = REQUIRED_HTTP_FILES.filter((relativePath) => !fs.existsSync(path.join(distRoot, relativePath)));
+  if (missing.length > 0) {
+    throw new Error(`HTTP contract failed. Missing required dist files: ${missing.join(', ')}`);
+  }
+
+  console.log(`HTTP contract validation passed: ${REQUIRED_HTTP_FILES.length} required files verified.`);
+}
+
+main();

--- a/docs/INCIDENTS.md
+++ b/docs/INCIDENTS.md
@@ -52,3 +52,16 @@
 
 ## Mandatory SW Note
 - For SW incidents: always bump cache prefixes to invalidate old caches.
+
+## Incident Log
+
+### 2026-02-19 - Legacy Root Route 404 After Astro Cutover
+- Impact: production 404s on legacy root routes (`/bebidas.html`, `/vinos.html`, `/e.html`, `/offline.html`).
+- Detection: production HTTP contract sweep failed while `/pages/*.html` remained available.
+- Root cause: postbuild only flattened `/pages/*.html` and did not copy required legacy pages to `astro-poc/dist/` root.
+- Fix: PR #224 (`e60f494c338677ba18ddd4e8802483487f53a073`) generated root compatibility pages and enforced contract validation.
+- Recovery SHA: `90ccf2aa65f14ce8c768f6fdced4085350340451` (deployed via `static.yml`).
+- Preventive controls:
+  - Build-time HTTP contract script (`astro-poc/scripts/validate-http-contract.mjs`).
+  - CI step to validate Astro HTTP contract explicitly.
+  - Dedicated rollback workflow for arbitrary SHA deploy (`.github/workflows/rollback.yml`).

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "smoke:evidence": "node scripts/smoke-evidence.mjs",
     "monitor:live-contract": "node tools/live-contract-monitor.mjs --timeout-ms 15000 --sample-size 20 --report reports/live-contract/latest.json",
     "certify:migration:prepare": "node -e \"const fs=require('fs'); ['build-determinism-a','build-determinism-b'].forEach((p)=>fs.rmSync(p,{recursive:true,force:true}));\"",
-    "certify:migration": "npm run certify:migration:prepare && npm run lint && npm run typecheck && npm run build && npm test && npm run test:e2e:astro && npm --prefix astro-poc run build && npm --prefix astro-poc run assets:validate && npm --prefix astro-poc run contract:artifacts",
+    "certify:migration": "npm run certify:migration:prepare && npm run lint && npm run typecheck && npm run build && npm test && npm run test:e2e:astro && npm --prefix astro-poc run build && npm --prefix astro-poc run assets:validate && npm --prefix astro-poc run contract:http && npm --prefix astro-poc run contract:artifacts",
     "lighthouse:audit": "node tools/lighthouse-audit.mjs",
     "snapshot": "node tools/snapshot-site.mjs --tag dev"
   },

--- a/tools/live-contract-monitor.mjs
+++ b/tools/live-contract-monitor.mjs
@@ -21,10 +21,11 @@ const KEY_ROUTES = [
 
 const PRODUCT_ASSET_FIELDS = ['image_path', 'image_avif_path', 'thumbnail_path'];
 
-function normalizeBaseUrl() {
-  const parsed = new URL(DEFAULT_BASE_URL);
+function normalizeBaseUrl(rawBaseUrl = DEFAULT_BASE_URL) {
+  const candidate = typeof rawBaseUrl === 'string' && rawBaseUrl.trim() ? rawBaseUrl.trim() : DEFAULT_BASE_URL;
+  const parsed = new URL(candidate);
   if (parsed.protocol !== 'https:') {
-    throw new Error(`Base URL must use HTTPS: ${DEFAULT_BASE_URL}`);
+    throw new Error(`Base URL must use HTTPS: ${candidate}`);
   }
   parsed.pathname = '';
   parsed.search = '';
@@ -186,6 +187,7 @@ async function runMonitor({ baseUrl, timeoutMs, sampleSize, reportPath }) {
 async function runCli() {
   const { values } = parseArgs({
     options: {
+      'base-url': { type: 'string' },
       'timeout-ms': { type: 'string' },
       'sample-size': { type: 'string' },
       report: { type: 'string' },
@@ -193,7 +195,7 @@ async function runCli() {
     allowPositionals: false,
   });
 
-  const baseUrl = normalizeBaseUrl();
+  const baseUrl = normalizeBaseUrl(values['base-url']);
   const timeoutRaw = Number(values['timeout-ms']);
   const sampleRaw = Number(values['sample-size']);
   const timeoutMs = Number.isFinite(timeoutRaw) && timeoutRaw > 0 ? timeoutRaw : DEFAULT_TIMEOUT_MS;


### PR DESCRIPTION
## Summary
- add deterministic rollback workflow (`rollback.yml`) that deploys any requested ref/SHA with explicit confirmation
- extend `static.yml` manual dispatch with optional `deploy_ref` for controlled SHA deploys
- add build-time HTTP contract script for legacy root pages and wire it into Astro build
- enforce Astro HTTP contract in CI and migration certification
- extend live contract monitor with `--base-url`
- update migration closeout docs (`MIGRATION_DONE.md`, `RUNBOOK_MIGRATION_ASTRO.md`, `docs/INCIDENTS.md`)

## Key guardrails
- rollback now supports arbitrary SHA deploy via workflow dispatch
- HTTP contract hard-fails build when required pages are missing
- CI contains explicit Astro HTTP contract validation step

## Local verification
- npm ci
- npm --prefix astro-poc ci
- npm test
- npm run test:e2e:astro
- npm --prefix astro-poc run build
- node tools/live-contract-monitor.mjs --base-url https://www.elrincondeebano.com --sample-size 50
