### PR TITLE
[codex] repair failing CI workflows

### DIFF
--- a/.github/workflows/product-data-guard.yml
+++ b/.github/workflows/product-data-guard.yml
@@ -124,6 +124,7 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git add data/product_data.json robots.txt astro-poc/public/robots.txt || true
           git add assets/images/og/ || true
+          git add assets/images/web/ || true
           if git diff --cached --quiet; then
             echo "No synced changes remained after rebuild. Skipping commit."
             exit 0

--- a/astro-poc/src/components/ServiceGuideDialog.astro
+++ b/astro-poc/src/components/ServiceGuideDialog.astro
@@ -4,7 +4,7 @@ export interface Props {
   targetLabel?: string;
 }
 
-const { targetHref = '#products-heading', targetLabel = 'Ir al catálogo' } = Astro.props;
+const { targetHref = '#catalog-section', targetLabel = 'Ir al catálogo' } = Astro.props;
 ---
 
 <dialog

--- a/astro-poc/src/pages/combos.astro
+++ b/astro-poc/src/pages/combos.astro
@@ -27,7 +27,7 @@ const sharePreview = createSharePreviewMetadata({
     <div class="category-intro-copy">
       <div class="category-intro-headline">
         <h1 id="combos-page-heading" class="mb-0">Combos listos</h1>
-        <a class="btn btn-outline-primary hero-secondary" href="/#products-heading">
+        <a class="btn btn-outline-primary hero-secondary" href="/#catalog-section">
           Seguir comprando
         </a>
       </div>
@@ -43,7 +43,7 @@ const sharePreview = createSharePreviewMetadata({
     description="Cada combo agrega productos relacionados al carrito en un solo paso, sin depender del scroll del catálogo."
     bundles={bundles}
     className="home-layout__bundles"
-    footerHref="/#products-heading"
+    footerHref="/#catalog-section"
     footerLabel="Volver al catálogo principal"
   />
   <script

--- a/docs/repo/ACTIVE_SURFACES.json
+++ b/docs/repo/ACTIVE_SURFACES.json
@@ -19,7 +19,6 @@
   },
   "workflows": [
     ".github/workflows/ci.yml",
-    ".github/workflows/ci-guardrails.yml",
     ".github/workflows/static.yml",
     ".github/workflows/security-audit.yml",
     ".github/workflows/live-contract-monitor.yml"

--- a/test/e2e-astro/mobile-home-ux.spec.ts
+++ b/test/e2e-astro/mobile-home-ux.spec.ts
@@ -122,13 +122,13 @@ for (const viewport of MOBILE_VIEWPORTS) {
 
     const layoutState = await page.evaluate(() => {
       const quickOrderHeading = document.getElementById('home-quick-order-heading');
-      const heading = document.getElementById('products-heading');
+      const catalogSection = document.getElementById('catalog-section');
       const firstProduct = document.querySelector('.category-strip .strip-card.producto');
       const quickOrderTop = quickOrderHeading
         ? quickOrderHeading.getBoundingClientRect().top + window.scrollY
         : Number.POSITIVE_INFINITY;
-      const catalogTop = heading
-        ? heading.getBoundingClientRect().top + window.scrollY
+      const catalogTop = catalogSection
+        ? catalogSection.getBoundingClientRect().top + window.scrollY
         : Number.POSITIVE_INFINITY;
       const firstProductTop =
         firstProduct instanceof HTMLElement

--- a/test/e2e-astro/ver-combos-nav.spec.ts
+++ b/test/e2e-astro/ver-combos-nav.spec.ts
@@ -84,7 +84,7 @@ test.describe('Ver combos navigation', () => {
 
     const pageState = await page.evaluate(() => {
       const cards = document.querySelectorAll('.bundle-card');
-      const backLink = document.querySelector('a[href="/#products-heading"]');
+      const backLink = document.querySelector('a[href="/#catalog-section"]');
       return {
         cardCount: cards.length,
         backHref: backLink?.getAttribute('href') || '',
@@ -92,7 +92,7 @@ test.describe('Ver combos navigation', () => {
     });
 
     expect(pageState.cardCount).toBeGreaterThan(0);
-    expect(pageState.backHref).toBe('/#products-heading');
+    expect(pageState.backHref).toBe('/#catalog-section');
 
     await page.locator('.bundle-card__action').first().click();
     await expect(page.locator('#cartOffcanvas')).toBeVisible();
@@ -101,9 +101,9 @@ test.describe('Ver combos navigation', () => {
     await page.locator('#continue-shopping').click();
     await expect(page.locator('#cartOffcanvas')).toBeHidden();
 
-    await page.locator('a[href="/#products-heading"]').first().click();
-    await expect(page).toHaveURL(/\/#products-heading$/);
+    await page.getByRole('link', { name: 'Volver al catálogo principal' }).click();
+    await expect(page).toHaveURL(/\/#catalog-section$/);
     await waitForReady(page);
-    await expect(page.locator('#products-heading')).toBeVisible();
+    await expect(page.locator('#catalog-section')).toBeVisible();
   });
 });

--- a/test/post-deploy-workflow.test.js
+++ b/test/post-deploy-workflow.test.js
@@ -10,7 +10,10 @@ const workflow = fs.readFileSync(workflowPath, 'utf8');
 
 test('post-deploy live probe runs a browser contract before the fetch-based canary', () => {
   const liveProbeIndex = workflow.indexOf('live-probe:');
-  const installDepsIndex = workflow.indexOf('- name: Install dependencies', liveProbeIndex);
+  const setupDepsIndex = workflow.indexOf(
+    '- uses: ./.github/actions/setup-node-and-deps',
+    liveProbeIndex
+  );
   const installChromiumIndex = workflow.indexOf(
     '- name: Install Playwright Chromium',
     liveProbeIndex
@@ -29,7 +32,11 @@ test('post-deploy live probe runs a browser contract before the fetch-based cana
     -1,
     'expected the post-deploy workflow to define the live-probe job'
   );
-  assert.notEqual(installDepsIndex, -1, 'expected the live-probe job to install dependencies');
+  assert.notEqual(
+    setupDepsIndex,
+    -1,
+    'expected the live-probe job to set up Node and install dependencies'
+  );
   assert.notEqual(
     installChromiumIndex,
     -1,
@@ -46,7 +53,7 @@ test('post-deploy live probe runs a browser contract before the fetch-based cana
     'expected the live-probe job to keep the fetch-based live canary'
   );
   assert.ok(
-    installChromiumIndex > installDepsIndex,
+    installChromiumIndex > setupDepsIndex,
     'Playwright Chromium install should happen after dependency install'
   );
   assert.ok(

--- a/test/static-deploy-workflow.test.js
+++ b/test/static-deploy-workflow.test.js
@@ -10,7 +10,10 @@ const workflow = fs.readFileSync(workflowPath, 'utf8');
 
 test('static deploy workflow gates Pages publish behind the browser canary', () => {
   const buildIndex = workflow.indexOf('- name: Build storefront');
-  const browserInstallIndex = workflow.indexOf('- name: Install Playwright browsers', buildIndex);
+  const setupPlaywrightIndex = workflow.indexOf(
+    '- uses: ./.github/actions/setup-playwright',
+    buildIndex
+  );
   const canaryIndex = workflow.indexOf(
     '- name: Run blocking browser canary against the shipped artifact',
     buildIndex
@@ -18,14 +21,11 @@ test('static deploy workflow gates Pages publish behind the browser canary', () 
   const deployIndex = workflow.indexOf('- name: Deploy to GitHub Pages', buildIndex);
 
   assert.notEqual(buildIndex, -1, 'expected deploy workflow to build the storefront');
-  assert.notEqual(browserInstallIndex, -1, 'expected deploy workflow to install Playwright');
+  assert.notEqual(setupPlaywrightIndex, -1, 'expected deploy workflow to set up Playwright');
   assert.notEqual(canaryIndex, -1, 'expected deploy workflow to run the blocking browser canary');
   assert.notEqual(deployIndex, -1, 'expected deploy workflow to publish to Pages');
-  assert.ok(browserInstallIndex > buildIndex, 'Playwright install should happen after the build');
-  assert.ok(
-    canaryIndex > browserInstallIndex,
-    'browser canary should run after Playwright install'
-  );
+  assert.ok(setupPlaywrightIndex > buildIndex, 'Playwright setup should happen after the build');
+  assert.ok(canaryIndex > setupPlaywrightIndex, 'browser canary should run after Playwright setup');
   assert.ok(deployIndex > canaryIndex, 'Pages deploy should happen only after the browser canary');
   assert.match(
     workflow,


### PR DESCRIPTION
## Qué cambia

- elimina del manifiesto la referencia al workflow `ci-guardrails.yml`, ya fusionado en `ci.yml`
- alinea los contratos de los workflows con las composite actions actuales
- corrige el ancla del catálogo y las pruebas Playwright asociadas
- incluye `assets/images/web/` en el auto-commit de artefactos generados para Dependabot

## Causa raíz

La optimización reciente de CI eliminó pasos y workflows que varios contratos seguían buscando. La migración del catálogo a cintillos horizontales también dejó referencias a `#products-heading`. Además, el guard de reproducibilidad detectaba assets web regenerados que su job de auto-commit no añadía.

## Validación

- `npm run validate`
- `npm run test:e2e` — 38/38 pruebas
- Vitest — 17 archivos, 164 pruebas
- `git diff --check`