### PR TITLE
fix(ci): harden live contract monitoring

### DIFF
--- a/.github/workflows/live-contract-monitor.yml
+++ b/.github/workflows/live-contract-monitor.yml
@@ -30,9 +30,10 @@ jobs:
 
       - name: Run live contract monitor
         id: monitor
-        continue-on-error: true
+        shell: bash
         run: |
           mkdir -p reports/live-contract
+          set +e
           node tools/live-contract-monitor.mjs \
             --timeout-ms "15000" \
             --sample-size "20" \
@@ -40,6 +41,16 @@ jobs:
             --retry-delay-ms "1000" \
             --require-security-headers \
             --report reports/live-contract/latest.json
+          command_status="$?"
+          set -e
+
+          if [ ! -f reports/live-contract/latest.json ]; then
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit "$command_status"
+          fi
+
+          monitor_status="$(node -p "JSON.parse(require('fs').readFileSync('reports/live-contract/latest.json', 'utf8')).monitorStatus || 'failed'")"
+          echo "status=$monitor_status" >> "$GITHUB_OUTPUT"
 
       - name: Upload live monitor artifact
         if: always()
@@ -54,7 +65,7 @@ jobs:
         shell: bash
         run: |
           if [ -f reports/live-contract/latest.json ]; then
-            node -e "const fs=require('fs'); const r=JSON.parse(fs.readFileSync('reports/live-contract/latest.json','utf8')); console.log('## Live Contract Monitor'); console.log(''); console.log('- Base URL: ' + r.baseUrl); console.log('- Runner: github-hosted'); console.log('- Key routes checked: ' + r.keyRouteCount); console.log('- Assets sampled: ' + r.sampledAssetCount); console.log('- Availability failures: ' + r.failures.length); console.log('- Security header failures: ' + r.securityHeaderFailures.length); console.log('- HTML surface failures: ' + (r.htmlSurfaceFailures || []).length); console.log('- Strict security mode: ' + (r.requireSecurityHeaders ? 'enabled' : 'disabled')); console.log('- Result: ' + (r.success ? '✅ PASS' : '❌ FAIL'));" >> "$GITHUB_STEP_SUMMARY"
+            node -e "const fs=require('fs'); const r=JSON.parse(fs.readFileSync('reports/live-contract/latest.json','utf8')); const icon=r.monitorStatus==='passed'?'✅':r.monitorStatus==='inconclusive'?'⚠️':'❌'; console.log('## Live Contract Monitor'); console.log(''); console.log('- Base URL: ' + r.baseUrl); console.log('- Runner: github-hosted'); console.log('- Key routes checked: ' + r.keyRouteCount); console.log('- Assets sampled: ' + r.sampledAssetCount); console.log('- Confirmed availability failures: ' + (r.confirmedAvailabilityFailures || []).length); console.log('- Observer-blocked probes: ' + (r.observerBlockedFailures || []).length); console.log('- Security header failures: ' + r.securityHeaderFailures.length); console.log('- HTML surface failures: ' + (r.htmlSurfaceFailures || []).length); console.log('- Strict security mode: ' + (r.requireSecurityHeaders ? 'enabled' : 'disabled')); console.log('- Result: ' + icon + ' ' + String(r.monitorStatus || 'failed').toUpperCase());" >> "$GITHUB_STEP_SUMMARY"
           else
             {
               echo "## Live Contract Monitor"
@@ -75,7 +86,7 @@ jobs:
           fi
 
       - name: Ensure live-contract-monitor label exists
-        if: ${{ steps.monitor.outcome == 'failure' || steps.monitor.outcome == 'success' }}
+        if: ${{ always() && steps.monitor.outputs.status != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -86,25 +97,26 @@ jobs:
             --force
 
       - name: Open or update failure issue
-        if: ${{ steps.monitor.outcome == 'failure' }}
+        if: ${{ steps.monitor.outputs.status == 'failed' || steps.monitor.outputs.status == 'inconclusive' }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           ISSUE_NUMBER="$(gh issue list --state open --label live-contract-monitor --json number --jq '.[0].number')"
-          FAILURE_BODY="$(node -e "const fs=require('fs'); const r=JSON.parse(fs.readFileSync('reports/live-contract/latest.json','utf8')); const availability=r.failures.slice(0,20).map(f=>{ const details=[f.error ? 'error=' + f.error : '', f.server ? 'server=' + f.server : '', f.cfRay ? 'cf-ray=' + f.cfRay : '', Number.isFinite(f.attemptCount) ? 'attempts=' + f.attemptCount : '', f.retryReason ? 'retry=' + f.retryReason : ''].filter(Boolean).join(', '); return '- availability: ' + f.status + ' ' + f.url + (details ? ' (' + details + ')' : ''); }); const headers=r.securityHeaderFailures.slice(0,20).map(f=>'- headers: ' + f.url + ' missing=[' + f.missing.join(', ') + '] invalid=[' + f.invalid.join(', ') + ']'); const html=(r.htmlSurfaceFailures || []).slice(0,20).map(f=>'- html-surface: ' + f.url + ' findings=[' + f.findings.join(', ') + ']'); console.log(['Live contract monitor detected failures.','','Run: ' + process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID,'Generated at: ' + r.generatedAt,'Availability failures: ' + r.failures.length,'Security header failures: ' + r.securityHeaderFailures.length,'HTML surface failures: ' + (r.htmlSurfaceFailures || []).length,'Strict security mode: ' + (r.requireSecurityHeaders ? 'enabled' : 'disabled'),'','Failure summary:',...availability,...headers,...html].join('\n'));")"
+          ISSUE_TITLE="$(node -p "const r=JSON.parse(require('fs').readFileSync('reports/live-contract/latest.json','utf8')); r.monitorStatus === 'inconclusive' ? 'Live Contract Monitor blocked by Cloudflare' : 'Live Contract Monitor failure'")"
+          FAILURE_BODY="$(node -e "const fs=require('fs'); const r=JSON.parse(fs.readFileSync('reports/live-contract/latest.json','utf8')); const blocked=r.monitorStatus==='inconclusive'; const availability=(blocked?r.observerBlockedFailures:r.confirmedAvailabilityFailures).slice(0,20).map(f=>{ const details=[f.error ? 'error=' + f.error : '', f.server ? 'server=' + f.server : '', f.cfRay ? 'cf-ray=' + f.cfRay : '', f.cfMitigated ? 'cf-mitigated=' + f.cfMitigated : '', Number.isFinite(f.attemptCount) ? 'attempts=' + f.attemptCount : '', f.retryReason ? 'retry=' + f.retryReason : ''].filter(Boolean).join(', '); return '- availability: ' + f.status + ' ' + f.url + (details ? ' (' + details + ')' : ''); }); const headers=r.securityHeaderFailures.slice(0,20).map(f=>'- headers: ' + f.url + ' missing=[' + f.missing.join(', ') + '] invalid=[' + f.invalid.join(', ') + ']'); const html=(r.htmlSurfaceFailures || []).slice(0,20).map(f=>'- html-surface: ' + f.url + ' findings=[' + f.findings.join(', ') + ']'); console.log([blocked?'Cloudflare challenged the GitHub-hosted observer. This run is inconclusive; it does not demonstrate a production outage.':'Live contract monitor detected confirmed failures.','', 'Run: ' + process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY + '/actions/runs/' + process.env.GITHUB_RUN_ID,'Generated at: ' + r.generatedAt,'Status: ' + r.monitorStatus,'Confirmed availability failures: ' + r.confirmedAvailabilityFailures.length,'Observer-blocked probes: ' + r.observerBlockedFailures.length,'Security header failures: ' + r.securityHeaderFailures.length,'HTML surface failures: ' + (r.htmlSurfaceFailures || []).length,'Strict security mode: ' + (r.requireSecurityHeaders ? 'enabled' : 'disabled'),'','Current evidence:',...availability,...headers,...html].join('\n'));")"
 
           if [ -n "$ISSUE_NUMBER" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "$FAILURE_BODY"
+            gh issue edit "$ISSUE_NUMBER" --title "$ISSUE_TITLE" --body "$FAILURE_BODY"
           else
             gh issue create \
-              --title "Live Contract Monitor failure" \
+              --title "$ISSUE_TITLE" \
               --body "$FAILURE_BODY" \
               --label live-contract-monitor
           fi
 
       - name: Close existing monitor issue when healthy
-        if: ${{ steps.monitor.outcome == 'success' }}
+        if: ${{ steps.monitor.outputs.status == 'passed' }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -116,5 +128,9 @@ jobs:
           fi
 
       - name: Fail job when monitor fails
-        if: ${{ steps.monitor.outcome == 'failure' }}
+        if: ${{ steps.monitor.outputs.status == 'failed' }}
         run: exit 1
+
+      - name: Warn when the observer is challenged
+        if: ${{ steps.monitor.outputs.status == 'inconclusive' }}
+        run: echo "::warning::Cloudflare challenged the GitHub-hosted observer. The run is inconclusive, not a confirmed outage."

--- a/astro-poc/package.json
+++ b/astro-poc/package.json
@@ -14,7 +14,7 @@
     "dev": "astro dev",
     "lint": "node ../node_modules/eslint/bin/eslint.js .",
     "typecheck": "astro check",
-    "build": "npm run clean && npm run data:sync && npm run data:validate && astro build && node scripts/postbuild-legacy-pages.mjs && npm run assets:validate && npm run contract:http && npm run contract:artifacts",
+    "build": "npm run clean && npm run data:sync && npm run data:validate && astro build && node scripts/postbuild-legacy-pages.mjs && node scripts/postbuild-sitemap.mjs && npm run assets:validate && npm run contract:http && npm run contract:artifacts",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/astro-poc/scripts/validate-artifact-contract.mjs
+++ b/astro-poc/scripts/validate-artifact-contract.mjs
@@ -13,6 +13,7 @@ const REQUIRED_FILES = [
   'index.html',
   '404.html',
   'robots.txt',
+  'sitemap.xml',
   'sitemap-index.xml',
   'sitemap-0.xml',
   'service-worker.js',

--- a/docs/operations/EDGE_SECURITY_HEADERS.md
+++ b/docs/operations/EDGE_SECURITY_HEADERS.md
@@ -118,6 +118,9 @@ Automatización repo-side:
 
 - Push a `main` con cambios en `infra/cloudflare/edge-security-headers/**` o `tools/security-header-policy.mjs` dispara el workflow `Deploy Cloudflare Edge Security Headers`.
 - El workflow requiere el secret `CLOUDFLARE_API_TOKEN`.
+- Un deploy de Pages no despliega ni reemplaza el Worker. Si el workflow de edge falla por ausencia del
+  secret, producción conserva la versión anterior y el monitor debe seguir reportando ese drift; no se
+  debe relajar el baseline repo-side para hacerlo coincidir con un Worker obsoleto.
 
 Hardening adicional esperado en Cloudflare sobre HTML público (`www.elrincondeebano.com/*`):
 
@@ -145,6 +148,22 @@ Chequeos repo-side ya disponibles:
 - workflow `Deploy static content to Pages`; ahora ejecuta un browser canary bloqueante contra `astro-poc/dist` antes de publicar a Pages para validar `__APP_READY__`, service worker y cart boot path del bundle shipped
 - workflow `Post-Deploy Canary` con `require_security_headers=true`; ahora también ejecuta `tools/live-browser-contract.mjs` en el runner self-hosted para capturar errores de consola/CSP sobre la zona live antes del probe fetch-only
 - ambos probes live también fallan si detectan HTML público contaminado por scripts inyectados desde edge
+
+### Semántica del monitor en runners compartidos
+
+Cloudflare puede desafiar IPs compartidas de GitHub-hosted runners aunque el sitio esté disponible para
+usuarios normales. El monitor usa la señal documentada `cf-mitigated: challenge` y, como respaldo, la
+firma de la página de challenge para separar tres estados:
+
+- `passed`: todas las comprobaciones live fueron concluyentes y cumplieron el contrato;
+- `failed`: existe al menos un fallo confirmado de disponibilidad, headers o superficie HTML;
+- `inconclusive`: Cloudflare bloqueó al observador; el workflow emite una advertencia y mantiene una
+  incidencia operativa actualizada, pero no declara una caída ni valida headers sobre la página de challenge.
+
+La incidencia se actualiza en lugar de agregar comentarios diarios idénticos. Un `inconclusive` no debe
+cerrarse como si fuera un pase: para recuperar cobertura edge concluyente se necesita un runner con salida
+estable/permitida o una excepción Cloudflare autenticada y de alcance mínimo. No se deben permitir todos
+los rangos dinámicos de GitHub Actions ni desactivar fallos HTTP confirmados.
 
 ## Cierre de backlog
 

--- a/test/live-contract-monitor.test.js
+++ b/test/live-contract-monitor.test.js
@@ -191,6 +191,7 @@ test('checkUrl retries Cloudflare-like 403 responses before failing', async () =
           headers: {
             server: 'cloudflare',
             'cf-ray': 'retry-me',
+            'cf-mitigated': 'challenge',
             'content-type': 'text/html; charset=utf-8',
           },
         });
@@ -210,7 +211,116 @@ test('checkUrl retries Cloudflare-like 403 responses before failing', async () =
       assert.equal(result.retried, true);
       assert.equal(result.retryHistory.length, 2);
       assert.equal(result.retryHistory[0].status, 403);
-      assert.match(result.retryHistory[0].retryReason, /Cloudflare-managed challenge/);
+      assert.equal(result.retryHistory[0].retryReason, 'Cloudflare-managed challenge');
+    }
+  );
+});
+
+test('checkUrl treats a persistent Cloudflare challenge as observer blocking, not header drift', async () => {
+  const { checkUrl } = await loadModule();
+
+  await withMockedFetch(
+    async () =>
+      new Response('<html><title>Just a moment...</title></html>', {
+        status: 403,
+        headers: {
+          server: 'cloudflare',
+          'cf-ray': 'blocked-monitor',
+          'cf-mitigated': 'challenge',
+          'content-type': 'text/html; charset=utf-8',
+        },
+      }),
+    async () => {
+      const result = await checkUrl(SITE_ORIGIN, '/', 5000, {
+        maxAttempts: 2,
+        retryDelayMs: 0,
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.observerBlocked, true);
+      assert.equal(result.securityHeaders, null);
+      assert.equal(result.cfMitigated, 'challenge');
+      assert.equal(result.attemptCount, 2);
+    }
+  );
+});
+
+test('runMonitor reports Cloudflare observer blocking as inconclusive without masking real failures', async () => {
+  const { runMonitor } = await loadModule();
+
+  await withMockedFetch(
+    async () =>
+      new Response('<html><title>Just a moment...</title></html>', {
+        status: 403,
+        headers: {
+          server: 'cloudflare',
+          'cf-mitigated': 'challenge',
+          'content-type': 'text/html; charset=utf-8',
+        },
+      }),
+    async () => {
+      const captured = [];
+      await withMockedConsoleLog(
+        (value) => captured.push(value),
+        async () => {
+          await assert.doesNotReject(() =>
+            runMonitor({
+              baseUrl: SITE_ORIGIN,
+              timeoutMs: 5000,
+              sampleSize: 5,
+              reportPath: '',
+              requireSecurityHeaders: true,
+              maxAttempts: 1,
+              retryDelayMs: 0,
+            })
+          );
+        }
+      );
+
+      const report = JSON.parse(captured[0]);
+      assert.equal(report.monitorStatus, 'inconclusive');
+      assert.equal(report.conclusive, false);
+      assert.equal(report.success, false);
+      assert.equal(report.confirmedAvailabilityFailures.length, 0);
+      assert.equal(report.observerBlockedFailures.length, report.keyRouteCount);
+      assert.equal(report.securityHeaderFailures.length, 0);
+    }
+  );
+});
+
+test('runMonitor still fails for a confirmed non-challenge HTTP error', async () => {
+  const { runMonitor } = await loadModule();
+
+  await withMockedFetch(
+    createMonitorFetch([
+      [
+        '/pages/vinos.html',
+        () =>
+          new Response('not found', {
+            status: 404,
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+          }),
+      ],
+    ]),
+    async () => {
+      await withMockedConsoleLog(
+        () => {},
+        async () => {
+          await expectAsyncReject(
+            assert,
+            () =>
+              runMonitor({
+                baseUrl: SITE_ORIGIN,
+                timeoutMs: 5000,
+                sampleSize: 5,
+                reportPath: '',
+                maxAttempts: 1,
+                retryDelayMs: 0,
+              }),
+            /confirmed failing probe/
+          );
+        }
+      );
     }
   );
 });

--- a/test/live-contract-workflow.test.js
+++ b/test/live-contract-workflow.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fs = require('node:fs');
 const test = require('node:test');
 const assert = require('node:assert/strict');

--- a/test/live-contract-workflow.test.js
+++ b/test/live-contract-workflow.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const fs = require('node:fs');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const workflow = fs.readFileSync('.github/workflows/live-contract-monitor.yml', 'utf8');
+
+test('live contract workflow routes report status instead of raw process outcome', () => {
+  assert.match(workflow, /echo "status=\$monitor_status" >> "\$GITHUB_OUTPUT"/);
+  assert.match(workflow, /steps\.monitor\.outputs\.status == 'failed'/);
+  assert.match(workflow, /steps\.monitor\.outputs\.status == 'inconclusive'/);
+  assert.match(workflow, /steps\.monitor\.outputs\.status == 'passed'/);
+  assert.doesNotMatch(workflow, /steps\.monitor\.outcome/);
+});
+
+test('live contract workflow updates one incident and only blocks confirmed failures', () => {
+  assert.match(workflow, /gh issue edit "\$ISSUE_NUMBER"/);
+  assert.equal((workflow.match(/gh issue comment "\$ISSUE_NUMBER"/g) || []).length, 1);
+  assert.match(workflow, /Monitor recovered in run/);
+  assert.match(
+    workflow,
+    /name: Fail job when monitor fails[\s\S]*?if: \$\{\{ steps\.monitor\.outputs\.status == 'failed' \}\}/
+  );
+  assert.match(workflow, /Cloudflare challenged the GitHub-hosted observer/);
+});

--- a/tools/live-contract-monitor.mjs
+++ b/tools/live-contract-monitor.mjs
@@ -15,6 +15,7 @@ const DEFAULT_SAMPLE_SIZE = 20;
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAY_MS = 750;
 const FAILURE_SNIPPET_MAX_LENGTH = 220;
+const PRODUCT_DATA_ROUTE = '/data/product_data.json';
 const ALLOWED_PROBE_HOSTS = new Set(['www.elrincondeebano.com', 'elrincondeebano.com']);
 const PROBE_REQUEST_HEADERS = Object.freeze({
   accept:
@@ -40,7 +41,7 @@ const KEY_ROUTES = [
   '/sitemap.xml',
   '/404.html',
   '/service-worker.js',
-  '/data/product_data.json',
+  PRODUCT_DATA_ROUTE,
 ];
 
 const PRODUCT_ASSET_FIELDS = ['image_path', 'image_avif_path', 'thumbnail_path'];
@@ -140,6 +141,13 @@ function looksLikeCloudflareChallenge(bodySnippet) {
   );
 }
 
+function isCloudflareChallengeResponse(result) {
+  return (
+    String(result?.cfMitigated || '').toLowerCase() === 'challenge' ||
+    looksLikeCloudflareChallenge(result?.bodySnippet)
+  );
+}
+
 function classifyRetryableFailure(result) {
   if (!result || result.ok) {
     return '';
@@ -157,14 +165,8 @@ function classifyRetryableFailure(result) {
     return 'transient upstream or edge error';
   }
 
-  const server = String(result.server || '').toLowerCase();
-  const cloudflareManaged =
-    server.includes('cloudflare') ||
-    Boolean(result.cfRay) ||
-    looksLikeCloudflareChallenge(result.bodySnippet);
-
-  if (result.status === 403 && cloudflareManaged) {
-    return 'possible Cloudflare-managed challenge';
+  if (result.status === 403 && isCloudflareChallengeResponse(result)) {
+    return 'Cloudflare-managed challenge';
   }
 
   return '';
@@ -185,11 +187,13 @@ async function executeProbe(
       finalUrl: response.url,
       server: response.headers.get('server') || '',
       cfRay: response.headers.get('cf-ray') || '',
+      cfMitigated: response.headers.get('cf-mitigated') || '',
       contentType,
       bodySnippet: '',
-      securityHeaders: shouldInspectSecurityHeaders
-        ? inspectSecurityHeaders(response.headers)
-        : null,
+      securityHeaders:
+        response.status === 200 && shouldInspectSecurityHeaders
+          ? inspectSecurityHeaders(response.headers)
+          : null,
       htmlSurface: null,
       error: '',
     };
@@ -211,6 +215,7 @@ async function executeProbe(
       finalUrl: '',
       server: '',
       cfRay: '',
+      cfMitigated: '',
       contentType: '',
       bodySnippet: '',
       securityHeaders: null,
@@ -274,6 +279,7 @@ export async function checkUrl(baseUrl, routeOrPath, timeoutMs, options = {}) {
       contentType: probeResult.contentType,
       error: probeResult.error,
       bodySnippet: probeResult.bodySnippet,
+      cfMitigated: probeResult.cfMitigated,
       retryReason,
     });
 
@@ -284,6 +290,7 @@ export async function checkUrl(baseUrl, routeOrPath, timeoutMs, options = {}) {
         attemptCount: attempts.length,
         retried: attempts.length > 1,
         retryReason,
+        observerBlocked: isCloudflareChallengeResponse(probeResult),
         retryHistory: attempts,
       };
     }
@@ -333,14 +340,12 @@ export async function runMonitor({
     );
   }
 
-  const productDataResult = routeResults.find((result) =>
-    result.url.endsWith('/data/product_data.json')
-  );
+  const productDataResult = routeResults.find((result) => result.url.endsWith(PRODUCT_DATA_ROUTE));
   const assetResults = [];
   let sampledAssets = [];
 
   if (productDataResult?.ok) {
-    const productDataUrl = resolveProbeUrl(baseUrl, '/data/product_data.json');
+    const productDataUrl = resolveProbeUrl(baseUrl, PRODUCT_DATA_ROUTE);
     const productPayload = await (
       await fetchWithTimeout(productDataUrl, normalizedTimeoutMs)
     ).json();
@@ -368,16 +373,26 @@ export async function runMonitor({
   }
 
   const availabilityFailures = [...routeResults, ...assetResults].filter((result) => !result.ok);
+  const observerBlockedFailures = availabilityFailures.filter((result) => result.observerBlocked);
+  const confirmedAvailabilityFailures = availabilityFailures.filter(
+    (result) => !result.observerBlocked
+  );
   const securityHeaderFailures = routeResults
     .filter((result) => result.securityHeaders && !result.securityHeaders.ok)
     .map(summarizeSecurityHeaderFailure);
   const htmlSurfaceFailures = routeResults
     .filter((result) => result.htmlSurface && !result.htmlSurface.ok)
     .map(summarizePublicHtmlFailure);
-  const success =
-    availabilityFailures.length === 0 &&
-    htmlSurfaceFailures.length === 0 &&
-    (!requireSecurityHeaders || securityHeaderFailures.length === 0);
+  const hasConfirmedFailure =
+    confirmedAvailabilityFailures.length > 0 ||
+    htmlSurfaceFailures.length > 0 ||
+    (requireSecurityHeaders && securityHeaderFailures.length > 0);
+  const monitorStatus = hasConfirmedFailure
+    ? 'failed'
+    : observerBlockedFailures.length > 0
+      ? 'inconclusive'
+      : 'passed';
+  const success = monitorStatus === 'passed';
   const report = {
     generatedAt: new Date().toISOString(),
     startedAt,
@@ -392,6 +407,8 @@ export async function runMonitor({
     routeResults,
     assetResults,
     failures: availabilityFailures,
+    confirmedAvailabilityFailures,
+    observerBlockedFailures,
     securityHeaderBaselineRoutes: SECURITY_HEADER_BASELINE_ROUTES,
     securityHeaderFailures,
     htmlSurfaceBaselineRoutes: SECURITY_HEADER_BASELINE_ROUTES,
@@ -399,14 +416,18 @@ export async function runMonitor({
     availabilityOk: availabilityFailures.length === 0,
     securityHeadersOk: securityHeaderFailures.length === 0,
     htmlSurfaceOk: htmlSurfaceFailures.length === 0,
+    conclusive: monitorStatus !== 'inconclusive',
+    monitorStatus,
     success,
   };
 
   writeJsonReport(reportPath, report);
   console.log(JSON.stringify(report, null, 2));
 
-  if (availabilityFailures.length > 0) {
-    throw new Error(`Live contract monitor found ${availabilityFailures.length} failing probe(s).`);
+  if (confirmedAvailabilityFailures.length > 0) {
+    throw new Error(
+      `Live contract monitor found ${confirmedAvailabilityFailures.length} confirmed failing probe(s).`
+    );
   }
 
   if (requireSecurityHeaders && securityHeaderFailures.length > 0) {


### PR DESCRIPTION
## Summary

- classify Cloudflare challenge responses as an inconclusive observer block instead of a production outage
- avoid validating security headers on challenge pages while preserving blocking behavior for confirmed HTTP, header, and HTML regressions
- update the existing monitor issue in place to stop daily duplicate comments
- restore generation of the legacy `/sitemap.xml` and enforce it in the deploy artifact contract
- document the edge deployment and monitor semantics

## Root cause

The scheduled workflow moved from an unavailable self-hosted runner to shared GitHub-hosted IPs. Cloudflare challenges those IPs, and the monitor treated the challenge response and its headers as production content. A separate build omission also stopped shipping `/sitemap.xml`.

## Validation

- `npm run validate`
- `node --test test/live-contract-monitor.test.js test/live-contract-workflow.test.js`
- Astro build generated a 114-URL `sitemap.xml`
- artifact contract passed with 14 required files
- Prettier and `git diff --check`

## Rollback

`git revert e4759f1`