### PR TITLE
fix(security): reduce code scanning noise

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -52,6 +52,12 @@ jobs:
             --metrics=off \
             --sarif \
             --output reports/semgrep/results.sarif \
+            --exclude-rule html.security.audit.missing-integrity.missing-integrity \
+            --exclude-rule javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp \
+            --exclude-rule javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal \
+            --exclude-rule javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring \
+            --exclude-rule problem-based-packs.insecure-transport.js-node.using-http-server.using-http-server \
+            --exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \
             --exclude admin/product_manager/.venv-ci-admin \
             .
 

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -10,3 +10,4 @@ playwright-report/
 test-results/
 admin/product_manager/.venv*/
 coverage/
+.agents/

--- a/docs/security-scans/README.md
+++ b/docs/security-scans/README.md
@@ -15,3 +15,14 @@ This folder documents artifacts produced by the `Semgrep Security Scan` workflow
 
 - Treat it as a prioritized review queue, not as a release note.
 - Each entry includes severity, rule ID, location, and message for triage.
+
+## Signal policy
+
+- GitHub Code Scanning receives security findings, not general lint or style output.
+- Low-confidence audit heuristics that repeatedly flag trusted build paths, tests, or
+  local-only tooling are excluded from SARIF upload. ESLint and the quality-gate
+  workflows remain responsible for those code-quality checks.
+- Vendored agent skills under `.agents/` are outside the deployed application and
+  are excluded from the repository security scan.
+- High-confidence Semgrep findings remain visible for review, even when they may
+  ultimately require contextual dismissal.


### PR DESCRIPTION
## What changed

- exclude six low-confidence Semgrep audit heuristics from GitHub SARIF uploads
- exclude vendored `.agents/` skills from application security scanning
- document the Code Scanning signal policy

## Why

The retired Codacy workflow uploaded general lint and style findings as security alerts, leaving thousands of stale findings. The replacement Semgrep workflow still surfaced recurring low-confidence audit heuristics from trusted build scripts, tests, and non-deployed agent skills.

This keeps GitHub Code Scanning focused on high-confidence, actionable application and workflow findings without disabling security scanning.

## Impact

The filtered scan produces 12 high-confidence findings instead of 57. The 2,406 historical noise alerts were separately dismissed in GitHub, reducing open Code Scanning alerts from 2,418 to 12.

## Validation

- filtered Semgrep scan: 12 findings
- `npx prettier --check .github/workflows/semgrep.yml docs/security-scans/README.md`
- `git diff --check`
