### PR TITLE
docs: refresh repository guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ npm run validate:release
 
 `lint → typecheck → test → build → guardrails:assets → test:e2e → monitor:share-preview`
 
+The local `validate` command also runs the E2E selector guard before the test
+suite. See the exact executable stages in
+[docs/operations/VALIDATION_MATRIX.md](docs/operations/VALIDATION_MATRIX.md).
+
 Use the lighter baseline during iteration:
 
 ```bash
@@ -60,7 +64,8 @@ npm run build            # preflight pipeline + Astro build
 npm run guardrails:assets  # orphan-asset check
 ```
 
-Full CI equivalents are documented in [AGENTS.md](AGENTS.md#matriz-de-comandos-por-agente).
+Full CI equivalents are documented in
+[docs/operations/RUNBOOK.md](docs/operations/RUNBOOK.md#matriz-de-comandos-por-agente).
 
 ## Non-functional expectations
 
@@ -71,9 +76,14 @@ Full CI equivalents are documented in [AGENTS.md](AGENTS.md#matriz-de-comandos-p
   image tree, or route set unnecessarily; prefer indexed, cached, or batched
   approaches.
 - **Maintainability:** extend existing commands/modules before creating new
-  entry points, and keep long-lived constraints documented outside the PR.
+  entry points, apply DRY only to stable shared concepts, and favor simple,
+  narrow contracts under the SOLID and KISS guidance.
 - **Documentation:** update command, topology, and runbook docs in the same PR
-  whenever behavior or ownership changes.
+  whenever behavior or ownership changes; follow the
+  [documentation policy](docs/operations/DOCUMENTATION.md).
+- **AI/API efficiency:** retrieve focused context, preserve cacheable prompt
+  prefixes, and measure cost alongside first-pass quality; see
+  [AI and API efficiency](docs/operations/AI_EFFICIENCY.md).
 
 See [docs/architecture/ENGINEERING_PRIORITIES.md](docs/architecture/ENGINEERING_PRIORITIES.md)
 for the full non-functional guide.

--- a/README.md
+++ b/README.md
@@ -1,84 +1,119 @@
 # El Rincón de Ébano
 
-Static storefront for `https://www.elrincondeebano.com/`, built from the active Astro app in [`astro-poc/`](./astro-poc/) and shared root-level data/assets.
+Static, mobile-first storefront for [elrincondeebano.com](https://www.elrincondeebano.com/),
+built with Astro and a versioned product catalog. The repository contains the
+production storefront, catalog and image inputs, build tooling, automated tests,
+and operational runbooks.
 
-## Current Runtime Truth
+## At a glance
 
-- Production storefront: [`astro-poc/`](./astro-poc/)
-- Canonical browser runtime entry: [`astro-poc/src/scripts/storefront.js`](./astro-poc/src/scripts/storefront.js)
-- Phase 3 runtime modules: [`astro-poc/src/scripts/storefront/`](./astro-poc/src/scripts/storefront/)
-- Canonical production build: `npm run build`
-- Canonical browser suite: `npm run test:e2e`
-- Canonical type validation: `npm run typecheck`
-- Legacy Node + EJS storefront: archived reference only in [`docs/archive/LEGACY_STOREFRONT.md`](./docs/archive/LEGACY_STOREFRONT.md)
+| Area                         | Source of truth                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| Production app               | [`astro-poc/`](./astro-poc/)                                                   |
+| Browser entry point          | [`astro-poc/src/scripts/storefront.js`](./astro-poc/src/scripts/storefront.js) |
+| Product and category data    | [`data/`](./data/)                                                             |
+| Source assets                | [`assets/`](./assets/)                                                         |
+| Build and validation tooling | [`tools/`](./tools/) and root [`package.json`](./package.json)                 |
+| Contributor task router      | [`docs/START_HERE.md`](./docs/START_HERE.md)                                   |
 
-`preview.html` remains a local/demo artifact and is not part of the deploy contract.
+The shipped artifact is a static Astro site in `astro-poc/dist/`. There is no
+required application server. The former Node/EJS storefront is an archived
+reference, not part of the deployment contract.
 
-## Setup
+## Quick start
 
-Canonical cold-start setup lives in [docs/onboarding/BOOTSTRAP.md](./docs/onboarding/BOOTSTRAP.md).
+Prerequisite: Node `24.x`. The repository is an npm workspace, so the root
+lockfile covers both the tooling and the Astro app.
 
 ```bash
 npm run bootstrap
+npm run dev
 ```
 
-This installs dependencies for both the root tooling and the Astro storefront (`astro-poc/`). Equivalent to:
+`npm run bootstrap` performs a deterministic workspace install with `npm ci`.
+The development server prints its local URL after startup. Environment variables
+are optional for normal storefront work; see
+[`docs/onboarding/LOCAL_DEV.md`](./docs/onboarding/LOCAL_DEV.md) for admin and
+Cloudflare tasks.
+
+## Build and validate
 
 ```bash
-npm ci
-(cd astro-poc && npm ci)
-```
-
-Node `24.x` is the supported local and CI baseline.
-
-## Canonical Validation
-
-Use the supported validation tiers for storefront work:
-
-```bash
+npm run build
 npm run validate
 npm run validate:release
 ```
 
-Validation details:
+| Command                    | Use it for                                                                        |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| `npm run build`            | Canonical production build: preflight, generated assets, then Astro               |
+| `npm run validate`         | Local confidence: lint, types, selector guard, tests, build, and asset guardrails |
+| `npm run validate:release` | Ship gate: release stages plus browser tests and the live share-preview probe     |
+| `npm run test:e2e`         | Canonical Playwright suite in `test/e2e-astro/`                                   |
+| `npm run lighthouse:audit` | Performance evidence for rendering, navigation, bundle, or critical-fetch changes |
 
-- `npm run validate` is the fast local baseline: `lint → typecheck → test → build → guardrails:assets`.
-- `npm run validate:release` is the canonical ship gate: `validate` plus `test:e2e` and `monitor:share-preview`.
-- `npm run typecheck` runs the legacy root JS contract check plus Astro-native `astro check` for the active app.
-- `npm run test:e2e` runs `playwright.astro.config.ts` against the canonical Astro suite in [`test/e2e-astro/`](./test/e2e-astro/).
-- Shopper-state persistence for the shipped storefront is canonical under the `astro-poc-*` localStorage keys; the legacy `cart` key is read only as a compatibility alias during upgrade.
-- Specs under [`test/e2e/`](./test/e2e/) plus the targeted Cypress runner are supplemental/manual coverage and are not the default release gate.
-- Supported WhatsApp/social preview routes are `/`, `/<category>/`, and `/p/<sku>/`; legacy `/c/*` and `/pages/*.html` routes stay compatible but are not part of the supported preview contract.
-- Social-preview metadata and image versioning are centralized in [`astro-poc/src/lib/seo.ts`](./astro-poc/src/lib/seo.ts), and `npm run monitor:share-preview` is the dedicated live check for public unfurls.
+Run `build` and `test:e2e` sequentially on Windows because both use generated
+Astro output. The release gate includes a live network probe and is therefore
+slower and dependent on the deployed site.
 
-## Build Notes
+## How the build works
 
-- Root `data/` and `assets/` remain shared inputs to the Astro storefront.
-- `npm run build` runs the shared preflight pipeline and then builds `astro-poc/dist/`.
-- `npm run build` and `npm run test:e2e` should be executed sequentially on Windows because they touch the same generated output.
+```text
+data/ + assets/ + config/
+          |
+          v
+   npm run preflight
+          |
+          v
+   Astro static build
+          |
+          v
+   astro-poc/dist/
+```
 
-## Engineering Priorities
+Always build from the repository root with `npm run build`. Calling Astro
+directly skips the shared preflight contract and can produce incomplete output.
 
-- Performance, scalability, maintainability, and documentation-quality
-  expectations are documented in
-  [`docs/architecture/ENGINEERING_PRIORITIES.md`](./docs/architecture/ENGINEERING_PRIORITIES.md).
-- For rendering, bundle, navigation, or critical data-fetch changes, attach
-  `npm run lighthouse:audit` evidence or equivalent performance notes in the PR.
-- For command, topology, or workflow changes, update the relevant docs in the
-  same PR so entry-point docs remain trustworthy.
+## Working in the repository
 
-## Key Docs
+- Start with [`docs/START_HERE.md`](./docs/START_HERE.md) to select the correct
+  code surface and validation tier.
+- Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before opening a pull request.
+- Apply the maintainability rules in
+  [`docs/architecture/ENGINEERING_PRIORITIES.md`](./docs/architecture/ENGINEERING_PRIORITIES.md),
+  including the repository's pragmatic DRY, SOLID, and KISS guidance.
+- For agent or API-assisted work, follow
+  [`docs/operations/AI_EFFICIENCY.md`](./docs/operations/AI_EFFICIENCY.md) to
+  reduce token and tool consumption without weakening verification.
+- When commands, ownership, or behavior change, update the affected docs in the
+  same pull request. The freshness policy is in
+  [`docs/operations/DOCUMENTATION.md`](./docs/operations/DOCUMENTATION.md).
 
-- [`docs/START_HERE.md`](./docs/START_HERE.md)
-- [`docs/architecture/ENGINEERING_PRIORITIES.md`](./docs/architecture/ENGINEERING_PRIORITIES.md)
-- [`docs/operations/VALIDATION_MATRIX.md`](./docs/operations/VALIDATION_MATRIX.md)
-- [`docs/operations/QUALITY_GUARDRAILS.md`](./docs/operations/QUALITY_GUARDRAILS.md)
-- [`docs/operations/DEBUGGING.md`](./docs/operations/DEBUGGING.md)
-- [`docs/operations/RUNBOOK.md`](./docs/operations/RUNBOOK.md)
-- [`docs/operations/SHARE_PREVIEW.md`](./docs/operations/SHARE_PREVIEW.md)
-- [`docs/implementation/ELRINCONDEEBANO_REMEDIATION_PLAN.md`](./docs/implementation/ELRINCONDEEBANO_REMEDIATION_PLAN.md)
-- [`docs/implementation/ELRINCONDEEBANO_REMEDIATION_BACKLOG.md`](./docs/implementation/ELRINCONDEEBANO_REMEDIATION_BACKLOG.md)
+## Documentation map
 
----
+| Need                     | Document                                                                         |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| First setup              | [`docs/onboarding/BOOTSTRAP.md`](./docs/onboarding/BOOTSTRAP.md)                 |
+| Local development        | [`docs/onboarding/LOCAL_DEV.md`](./docs/onboarding/LOCAL_DEV.md)                 |
+| Repository architecture  | [`docs/architecture/CODEBASE_MAP.md`](./docs/architecture/CODEBASE_MAP.md)       |
+| Validation requirements  | [`docs/operations/VALIDATION_MATRIX.md`](./docs/operations/VALIDATION_MATRIX.md) |
+| Operations and incidents | [`docs/operations/RUNBOOK.md`](./docs/operations/RUNBOOK.md)                     |
+| Share-preview contract   | [`docs/operations/SHARE_PREVIEW.md`](./docs/operations/SHARE_PREVIEW.md)         |
+| Documentation ownership  | [`docs/operations/DOCUMENTATION.md`](./docs/operations/DOCUMENTATION.md)         |
+| Historical decisions     | [`docs/adr/README.md`](./docs/adr/README.md)                                     |
 
-Built and maintained by **Carlos Ortega** — automation, data systems, and web technical hygiene consulting. Portfolio and services: **[tooltician.com](https://tooltician.com/)**.
+## Production contract
+
+- Supported public routes: `/`, `/<category>/`, and `/p/<sku>/`.
+- Catalog and assets are versioned build inputs; generated output is not edited
+  by hand.
+- Social metadata and image versioning are centralized in
+  [`astro-poc/src/lib/seo.ts`](./astro-poc/src/lib/seo.ts).
+- Shopper state uses `astro-poc-*` local-storage keys. The old `cart` key is a
+  read-only upgrade alias.
+
+## License and maintainer
+
+Licensed under ISC. Built and maintained by **Carlos Ortega** — automation,
+data systems, and web technical-hygiene consulting at
+[tooltician.com](https://tooltician.com/).

--- a/docs/GEMINI.md
+++ b/docs/GEMINI.md
@@ -13,36 +13,37 @@ Gemini acts as a dynamic agent capable of fulfilling multiple roles defined in t
 
 ## Verified Commands
 
-Gemini must prioritize using these verified commands as per the [Command Matrix](AGENTS.md#matriz-de-comandos-por-agente):
+Gemini must prioritize these verified commands from the
+[command matrix](./operations/RUNBOOK.md#matriz-de-comandos-por-agente):
 
-| Purpose           | Command                    | Success Criteria                                        |
-| ----------------- | -------------------------- | ------------------------------------------------------- |
-| **Discovery**     | `node -v`                  | Version must match `24.x`                               |
-| **Build**         | `npm run build`            | Exit code 0, no critical warnings, artifacts in `dist/` |
-| **Test (Full)**   | `npm ci && npm test`       | Exit code 0, all tests passed                           |
-| **Test (Single)** | `node test/<name>.test.js` | Exit code 0                                             |
-| **Lint**          | `npx eslint .`             | Exit code 0                                             |
-| **Security**      | `npm audit --production`   | No High/Critical vulnerabilities                        |
+| Purpose           | Command                    | Success Criteria                                                  |
+| ----------------- | -------------------------- | ----------------------------------------------------------------- |
+| **Discovery**     | `node -v`                  | Version must match `24.x`                                         |
+| **Build**         | `npm run build`            | Exit code 0, no critical warnings, artifacts in `astro-poc/dist/` |
+| **Test (Full)**   | `npm test`                 | Exit code 0, all tests passed                                     |
+| **Test (Single)** | `node test/<name>.test.js` | Exit code 0                                                       |
+| **Lint**          | `npm run lint`             | Exit code 0                                                       |
+| **Security**      | `npm audit --omit=dev`     | No high/critical production vulnerabilities                       |
 
 ## Guardrails (Checklist)
 
 Before declaring a task complete, Gemini must ensure:
 
-1.  **Deterministic Environment**:
-    - [ ] `node -v` confirmed as `24.x`.
-    - [ ] Used `npm ci` for dependencies (never `npm install` unless updating lockfile).
+1. **Deterministic Environment**:
+   - [ ] `node -v` confirmed as `24.x`.
+   - [ ] Used `npm ci` for dependencies (never `npm install` unless updating lockfile).
 
-2.  **Strict Compilation**:
-    - [ ] `npm run build` passes.
+2. **Strict Compilation**:
+   - [ ] `npm run build` passes.
 
-3.  **Test Integrity**:
-    - [ ] `npm test` passes completely.
-    - [ ] No `test.skip` or commented-out tests introduced without explicit user approval.
-    - [ ] Mutations/Survivors addressed (if applicable).
+3. **Test Integrity**:
+   - [ ] `npm test` passes completely.
+   - [ ] No `test.skip` or commented-out tests introduced without explicit user approval.
+   - [ ] Mutations/Survivors addressed (if applicable).
 
-4.  **Code Quality**:
-    - [ ] ESLint checks pass.
-    - [ ] No secrets logged to console.
+4. **Code Quality**:
+   - [ ] ESLint checks pass.
+   - [ ] No secrets logged to console.
 
 ## PR & Change Policy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,12 @@
 # Documentation Index
 
 - `docs/START_HERE.md`: single task router for agents and contributors.
+- `README.md`: human-oriented project overview and quick start.
+- `CONTRIBUTING.md`: pull-request workflow and contributor checklist.
 
 ## Onboarding
 
-- `docs/onboarding/BOOTSTRAP.md`: canonical cold-start setup for the dual-root repo.
+- `docs/onboarding/BOOTSTRAP.md`: canonical npm-workspace cold start.
 - `docs/onboarding/LOCAL_DEV.md`: local preview, runtime flags, and optional admin-tool setup.
 
 ## Operations
@@ -16,6 +18,8 @@
 - `docs/operations/OBSERVABILITY.md`: telemetry and monitoring baseline.
 - `docs/operations/SMOKE_TEST.md`: manual smoke checklist.
 - `docs/operations/DEPENDENCY_POLICY.md`: upgrade cadence, risk tiers, and rollback rules.
+- `docs/operations/DOCUMENTATION.md`: freshness, ownership, and human-writing policy.
+- `docs/operations/AI_EFFICIENCY.md`: token, context, caching, and tool-efficiency guidance.
 - `docs/operations/DEBUGGING.md`: standard local/CI debugging workflow.
 - `docs/operations/INCIDENT_TRIAGE.md`: incident severity and triage sequence.
 - `docs/operations/ROLLBACK.md`: rollback procedures and validation gates.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -23,17 +23,19 @@ changes.
 | Build pipeline or generated assets                | `tools/`, `config/`, root `package.json`                | `npm run validate:release`                                                          | `docs/repo/STRUCTURE.md`                      |
 | CI workflows or release gating                    | `.github/workflows/`, `tools/`, `package.json`          | `npm run validate:release`                                                          | `docs/operations/RUNBOOK.md`                  |
 | Performance, scalability, or maintainability work | `astro-poc/`, `src/js/`, `tools/`, `docs/`              | `npm run validate:release` plus `npm run lighthouse:audit` when UX/perf is affected | `docs/architecture/ENGINEERING_PRIORITIES.md` |
-| Docs, runbooks, or ADRs                           | `docs/`                                                 | `npm run validate`                                                                  | `docs/README.md`                              |
+| Docs, runbooks, or ADRs                           | `README.md`, `CONTRIBUTING.md`, `docs/`                 | Markdown lint, then `npm run validate` when executable contracts are affected       | `docs/operations/DOCUMENTATION.md`            |
+| Agent prompts, context, or API-token efficiency   | Agent config and the owning workflow                    | Measure tokens, retries, latency, and first-pass success                            | `docs/operations/AI_EFFICIENCY.md`            |
 
 ## Canonical commands
 
-| Goal                     | Command                         |
-| ------------------------ | ------------------------------- |
-| Fast local confidence    | `npm run validate`              |
-| Full release gate        | `npm run validate:release`      |
-| Build only               | `npm run build`                 |
-| Browser suite only       | `npm run test:e2e`              |
-| Live share-preview probe | `npm run monitor:share-preview` |
+| Goal                     | Command                                       |
+| ------------------------ | --------------------------------------------- |
+| Fast local confidence    | `npm run validate`                            |
+| Full release gate        | `npm run validate:release`                    |
+| Build only               | `npm run build`                               |
+| Browser suite only       | `npm run test:e2e`                            |
+| Live share-preview probe | `npm run monitor:share-preview`               |
+| Markdown lint            | `npx markdownlint-cli2 'docs/**/*.md' '*.md'` |
 
 ## Ground rules
 
@@ -44,3 +46,5 @@ changes.
   performance, scalability, maintainability, or doc-quality goals.
 - Follow the ADRs for decisions that affect runtime topology, validation, or
   deployment.
+- Treat audit and migration files as historical evidence; use current entry
+  points for active instructions.

--- a/docs/architecture/CODEBASE_MAP.md
+++ b/docs/architecture/CODEBASE_MAP.md
@@ -15,9 +15,9 @@ Reference document for automated agents, CI tools, and new contributors. Maps ev
 | `astro-poc/`                     | **Production Astro storefront** — the canonical runtime (ADR-0003). Contains `src/`, `public/`, `scripts/`, and its own `package.json`.                             | Storefront dev                          | CI/CD (static.yml)             |
 | `astro-poc/dist/`                | Compiled static site. Git-ignored. Deployed to GitHub Pages.                                                                                                        | `npm run build`                         | GitHub Pages (static.yml)      |
 | `src/js/`                        | Shared typed JS modules (cart, logger, analytics, fetch). Covered by `tsconfig.typecheck.json`.                                                                     | Core dev                                | Astro storefront, tests        |
-| `test/`                          | All unit (Vitest), legacy integration (node:test), contract, guardrail, E2E (Playwright + Cypress) tests.                                                           | Test Sentinel                           | `npm test`, `npm run test:e2e` |
-| `tools/`                         | Preflight pipeline scripts (`preflight.js`), build utilities (image gen, guardrails, canary, lighthouse).                                                           | Repo Cartographer                       | `npm run build`, CI            |
-| `scripts/`                       | Developer utility scripts: dev server, smoke test, Cypress runner, CSS order check. Not part of the build.                                                          | Docs Steward                            | Local dev, CI smoke steps      |
+| `test/`                          | Unit, integration, contract, guardrail, and Playwright end-to-end tests.                                                                                            | Test Sentinel                           | `npm test`, `npm run test:e2e` |
+| `tools/`                         | Preflight pipeline scripts (`preflight.js`), build utilities (image generation, guardrails, canary, Lighthouse).                                                    | Repo Cartographer                       | `npm run build`, CI            |
+| `scripts/`                       | Developer utility scripts: dev server, smoke test, CI helpers, and CSS-order check. Not part of the build.                                                          | Docs Steward                            | Local dev, CI smoke steps      |
 | `admin/`                         | Python 3.12 GUI (`product_manager/`) for editing `data/product_data.json`. Separate runtime from Node storefront.                                                   | Product Manager                         | Manual use only                |
 | `config/`                        | Static config files read by build tools (e.g., `category_og_icon_map.json`).                                                                                        | Manual edits                            | tools/, preflight              |
 | `infra/cloudflare/`              | Cloudflare Workers source for edge security headers. Deployed via `npm run cloudflare:deploy:edge-security-headers`.                                                | Security agent                          | Cloudflare (manual deploy)     |
@@ -82,7 +82,6 @@ Typecheck scope is declared in [tsconfig.typecheck.json](../../tsconfig.typechec
 | Guardrail          | Vitest         | `test/*.guardrail.test.js`           | `npm test`                |
 | Build metadata     | Vitest         | `test/*.build-metadata.test.js`      | `npm test`                |
 | E2E — Astro        | Playwright     | `test/e2e-astro/**/*.spec.ts`        | `npm run test:e2e`        |
-| E2E — legacy       | Cypress        | `cypress/e2e/**/*.cy.ts`             | `npm run test:cypress`    |
 | Mutation           | Stryker        | `test/cart.spec.js` et al.           | `npx stryker run`         |
 | Visual regression  | Playwright     | `test/e2e/visual-regression.spec.ts` | `npm run test:e2e:visual` |
 
@@ -96,7 +95,7 @@ Typecheck scope is declared in [tsconfig.typecheck.json](../../tsconfig.typechec
 | -------------------------------------- | ----------------------------------------- | ---------------------------------------------- |
 | `static.yml`                           | push `main`, manual                       | Build Astro + deploy to GitHub Pages           |
 | `ci.yml`                               | push/PR `main`                            | Lint → build → tests → guardrails → lighthouse |
-| `ci-guardrails.yml`                    | push/PR `main`                            | Fast build + asset guardrails                  |
+| `quality-gates.yml`                    | push/PR `main`                            | Shell, workflow, Markdown, and quality linting |
 | `images.yml`                           | push `assets/images/originals/**`, manual | Generate image variants, auto-commit           |
 | `semgrep.yml`                          | push/PR `main`, weekly cron, manual       | SAST scan → SARIF → Code Scanning              |
 | `secret-scan.yml`                      | push/PR, weekly cron, manual              | Credential scan on versioned files             |

--- a/docs/architecture/ENGINEERING_PRIORITIES.md
+++ b/docs/architecture/ENGINEERING_PRIORITIES.md
@@ -71,7 +71,8 @@ Pay extra attention to:
 - `data/product_data.json` growth and any code that loads or transforms the full
   catalog;
 - `assets/images/` variant generation and orphan-asset detection;
-- browser-test scope growth in `test/e2e-astro/` and `cypress/e2e/`;
+- browser-test scope growth in canonical `test/e2e-astro/` and supplemental
+  `test/e2e/`;
 - scheduled live monitors that depend on network or third-party edge behavior.
 
 ## Maintainability
@@ -94,6 +95,32 @@ Pay extra attention to:
   only in PR descriptions or audit notes.
 - Keep PRs small enough to preserve rollback clarity; if the change mixes
   behavior, tooling, and docs, split it unless the coupling is unavoidable.
+
+### DRY, SOLID, and KISS
+
+Use these as decision tools, not abstraction quotas:
+
+- **DRY (Don't Repeat Yourself):** keep each business rule, schema, command, and
+  source-of-truth fact in one canonical place. Extract code after duplication
+  represents the same stable concept; do not merge coincidentally similar code
+  that is likely to evolve independently.
+- **SOLID:** give modules one reason to change, keep public contracts narrow,
+  extend behavior through small composable seams, preserve substitutability,
+  avoid forcing consumers to depend on unused interfaces, and inject external
+  effects at boundaries. In this mostly functional JavaScript codebase, module
+  boundaries and function contracts matter more than class hierarchies.
+- **KISS (Keep It Simple):** choose the smallest design that satisfies the
+  current contract and has a clear test and rollback path. Prefer plain data,
+  named functions, and existing commands over new frameworks, factories, or
+  configuration layers.
+
+When the rules pull in different directions, prioritize correctness and KISS,
+then remove proven duplication. Before adding an abstraction, answer:
+
+1. Which stable concept does it own?
+2. Which current callers need it?
+3. Is the new contract smaller and easier to test than the duplicated code?
+4. Can a future maintainer remove or change it without a repository-wide edit?
 
 ## Documentation Quality
 
@@ -122,3 +149,7 @@ Pay extra attention to:
   text on top of them.
 - If a decision is durable enough to surprise a future maintainer, capture it in
   an ADR or architecture doc.
+- Follow [`docs/operations/DOCUMENTATION.md`](../operations/DOCUMENTATION.md) for
+  source-of-truth order, freshness triggers, and human-writing standards.
+- Follow [`docs/operations/AI_EFFICIENCY.md`](../operations/AI_EFFICIENCY.md) for
+  context, caching, tool-output, and validation guidance in API-assisted work.

--- a/docs/archive/LEGACY_STOREFRONT.md
+++ b/docs/archive/LEGACY_STOREFRONT.md
@@ -4,16 +4,16 @@ Status: retired build path as of 2026-03-11.
 
 ## What this means
 
-- The active storefront in `main` is Astro under [`astro-poc/`](/home/carlos/VS_Code_Projects/Tienda%20Ebano/astro-poc).
+- The active storefront in `main` is Astro under [`astro-poc/`](../../astro-poc/).
 - Root `npm run build` now builds the Astro storefront through the shared asset preflight.
 - The historical Node + EJS pipeline no longer has supported package scripts or CI entrypoints.
-- The retired source was moved to [`_archive/legacy-storefront/`](/home/carlos/VS_Code_Projects/Tienda%20Ebano/_archive/legacy-storefront).
+- The retired source was moved to [`_archive/legacy-storefront/`](../../_archive/legacy-storefront/).
 
 ## Archived contents
 
-- Templates: [`_archive/legacy-storefront/templates/`](/home/carlos/VS_Code_Projects/Tienda%20Ebano/_archive/legacy-storefront/templates)
-- Builders: [`_archive/legacy-storefront/tools/`](/home/carlos/VS_Code_Projects/Tienda%20Ebano/_archive/legacy-storefront/tools)
-- Historical tests: [`_archive/legacy-storefront/tests/`](/home/carlos/VS_Code_Projects/Tienda%20Ebano/_archive/legacy-storefront/tests)
+- Templates: [`_archive/legacy-storefront/templates/`](../../_archive/legacy-storefront/templates/)
+- Builders: [`_archive/legacy-storefront/tools/`](../../_archive/legacy-storefront/tools/)
+- Historical tests: [`_archive/legacy-storefront/tests/`](../../_archive/legacy-storefront/tests/)
 
 These commands were removed from the active package surface and are no longer part of CI, release, or deploy flows.
 

--- a/docs/audit/plan-20260715-documentation-refresh.md
+++ b/docs/audit/plan-20260715-documentation-refresh.md
@@ -1,0 +1,42 @@
+# Documentation Refresh Plan
+
+Status: completed
+
+## Objective
+
+Make the repository documentation easier to navigate, cheaper for API-assisted
+work, explicit about DRY/SOLID/KISS tradeoffs, and less prone to stale current
+guidance.
+
+## Scope
+
+- Human entry points: `README.md`, `CONTRIBUTING.md`, and `docs/START_HERE.md`.
+- Canonical engineering, onboarding, validation, structure, and runbook docs.
+- A focused AI/API-efficiency guide and documentation freshness policy.
+- Verified active-doc drift only; historical audits and migration evidence are
+  intentionally preserved.
+
+## Completed work
+
+- [x] Inventory canonical commands, runtime pins, active paths, and workflows.
+- [x] Separate current guidance from historical records.
+- [x] Rewrite the README around quick start, validation, architecture, and docs navigation.
+- [x] Add measurable token-efficiency and prompt-caching guidance.
+- [x] Codify pragmatic DRY, SOLID, and KISS rules.
+- [x] Define source-of-truth order, document classes, freshness triggers, and human-writing rules.
+- [x] Repair confirmed workspace, validation, Cypress, workflow, and audit-command drift.
+- [x] Run Markdown formatting/lint and focused documentation checks.
+
+## Decisions
+
+- Keep provider-specific AI details in one dated guide and link to primary
+  documentation so entry points do not age with pricing or model names.
+- Do not rewrite dated audit and migration records: their old commands and
+  versions are evidence of the recorded event.
+- Prefer trigger-based freshness reviews over adding volatile timestamps to
+  every document.
+
+## Rollback
+
+Revert the documentation-refresh commit. No runtime or deployment behavior is
+changed by this plan.

--- a/docs/onboarding/BOOTSTRAP.md
+++ b/docs/onboarding/BOOTSTRAP.md
@@ -5,7 +5,7 @@ Canonical cold-start instructions for agents and contributors.
 ## Runtime baseline
 
 - Node 24.x
-- Deterministic install: `npm ci`
+- Deterministic workspace install: `npm ci`
 
 Keep `.nvmrc`, `.node-version`, `.tool-versions`, CI workflows, and
 `package.json` aligned to the same Node 24 baseline.
@@ -16,16 +16,17 @@ Keep `.nvmrc`, `.node-version`, `.tool-versions`, CI workflows, and
 2. Run `npm run bootstrap`.
 3. Run `npm run validate`.
 
-## Why not plain `npm ci`?
+## Why use the bootstrap command?
 
-This repository has two npm roots:
+This repository is an npm workspace with two packages:
 
 - `/`
 - `astro-poc/`
 
-Running only root `npm ci` leaves the Astro storefront dependencies uninstalled.
-`npm run bootstrap` is the only supported cold-start path because it installs
-both roots in the correct order.
+The root lockfile covers both packages, and `npm run bootstrap` currently wraps
+the correct deterministic root install (`npm ci`). Use the named command so the
+onboarding contract remains stable if installation steps change later. Do not
+run a second install inside `astro-poc/`.
 
 ## Optional environment setup
 

--- a/docs/operations/AI_EFFICIENCY.md
+++ b/docs/operations/AI_EFFICIENCY.md
@@ -1,0 +1,105 @@
+# AI and API Efficiency
+
+Verified: 2026-07-15
+
+Guidance for repository work performed with coding agents or language-model
+APIs. The goal is to minimize input, output, retries, and latency while
+preserving correctness, security, and the repository's validation contract.
+
+## Principles
+
+1. **Retrieve before reading.** Search for the relevant symbol, path, or literal
+   before loading files. Use CodeGraph for relationships and `rg` for literal
+   text. Read focused ranges instead of entire trees.
+2. **Send the smallest sufficient context.** Include the task, constraints,
+   relevant diff, and acceptance criteria. Do not repeatedly send generated
+   files, lockfiles, historical audits, or unrelated logs.
+3. **Keep reusable context stable.** Put durable instructions and tool schemas
+   first; put the request-specific material last. Current provider prompt
+   caches work best when requests share an exact, stable prefix.
+4. **Batch independent work.** Combine related searches and file reads, and run
+   independent checks together when they do not contend for generated output.
+   Keep `build` and browser tests sequential on Windows.
+5. **Persist conclusions, not transcripts.** Record durable decisions in code,
+   focused docs, ADRs, or versioned plans. Do not make future sessions recover
+   decisions from long chat histories.
+6. **Verify proportionally.** Start with the narrowest relevant check, then run
+   the required repository gate. Token savings never justify skipping tests,
+   security review, or release checks.
+
+## Efficient request shape
+
+A good task request contains four compact blocks:
+
+```text
+Outcome: the observable result to deliver
+Scope: files or subsystem in bounds
+Constraints: contracts that must not change
+Done when: commands and behavior that prove completion
+```
+
+Prefer a diff, failing assertion, or exact error excerpt over a complete log.
+When output is large, capture the command, exit code, and the smallest useful
+failure section. Avoid asking the model to restate files it has just edited.
+
+## Context and caching strategy
+
+- Keep agent instructions concise, non-duplicated, and linked to focused docs.
+- Put changing catalog rows, user input, diffs, and error messages after stable
+  instructions so cached prefixes remain reusable.
+- Reuse a conversation only while its context remains relevant. At a phase
+  boundary, retain a compact state summary: decisions, changed files, open
+  risks, and validation results.
+- Prefer references to versioned repository files over pasting their full
+  contents. Load the referenced section only when needed.
+- Do not add a retrieval layer, cache, or model router until measurements show
+  repeated work. Infrastructure that costs more to understand than it saves
+  violates KISS.
+
+## Model and tool routing
+
+- Use the least expensive model that reliably meets the task's reasoning and
+  code-quality needs; escalate on ambiguity, security impact, or failed review.
+- Use deterministic tools for deterministic work: formatters, linters, schema
+  validators, search, and tests should not be replaced by model inference.
+- Cap tool output and narrow queries early. A targeted second read is usually
+  cheaper than loading an entire repository or unbounded CI log.
+- Avoid duplicate verification. Trust successful deterministic output unless
+  inputs changed or a second method covers a distinct risk.
+
+## Measure before optimizing
+
+Track by task type, model, and workflow:
+
+| Signal                                   | Why it matters                                                |
+| ---------------------------------------- | ------------------------------------------------------------- |
+| Input and output tokens                  | Reveals oversized context and verbose responses               |
+| Cached-input tokens or cache-hit rate    | Shows whether stable prefixes are actually reused             |
+| Tool calls, retries, and failed calls    | Exposes poor routing and avoidable loops                      |
+| Wall time and cost per accepted change   | Prevents optimizing tokens while increasing latency or rework |
+| First-pass validation and review success | Protects quality from false economy                           |
+
+Set budgets from a measured baseline. Investigate regressions rather than
+enforcing a single token cap across documentation, debugging, and architecture
+work, which have different context needs.
+
+## Repository-specific checklist
+
+- Start at `docs/START_HERE.md`; do not rediscover the repository layout.
+- Use `docs/repo/ACTIVE_SURFACES.json` for canonical machine-readable paths.
+- Exclude `astro-poc/dist/`, dependency trees, reports, and archived docs unless
+  the task explicitly concerns them.
+- Keep one canonical command per workflow and one source of truth per fact.
+- Run `npm run validate` for the local baseline and
+  `npm run validate:release` only when its live and browser stages are required.
+- Report changed files, decisions, and validation outcomes; omit a narration of
+  every read-only command.
+
+## Current provider references
+
+These primary references describe the caching behavior behind the stable-prefix
+recommendation. Recheck them when provider behavior or pricing affects a design:
+
+- [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching)
+- [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+- [Gemini context caching](https://ai.google.dev/gemini-api/docs/caching)

--- a/docs/operations/DEBUGGING.md
+++ b/docs/operations/DEBUGGING.md
@@ -9,8 +9,7 @@ Estandarizar depuración local para fallos de build, test y runtime sin introduc
 1. Confirmar runtime:
    - `node -v` (objetivo 24.x)
 2. Instalar limpio:
-   - `npm ci`
-   - `(cd astro-poc && npm ci)`
+   - `npm run bootstrap`
 3. Reproducir fallo en el menor scope posible:
    - lint: `npm run lint`
    - typecheck canónico: `npm run typecheck`
@@ -61,7 +60,7 @@ Estandarizar depuración local para fallos de build, test y runtime sin introduc
    - ejecutar `build` y `e2e` en secuencia, no en paralelo.
 3. Falla solo en CI:
    - comparar versión de runtime y comandos exactos de workflow.
-   - replicar local con `npm ci` y `(cd astro-poc && npm ci)`.
+   - replicar local con `npm run bootstrap`.
 
 ## Evidencia mínima en PR
 

--- a/docs/operations/DOCUMENTATION.md
+++ b/docs/operations/DOCUMENTATION.md
@@ -1,0 +1,74 @@
+# Documentation Policy
+
+Verified: 2026-07-15
+
+This policy keeps documentation concise, current, and useful to humans and
+agents. The repository remains the source of truth; documentation explains the
+executable contract but does not override it.
+
+## Source-of-truth order
+
+When two sources disagree, resolve the discrepancy in this order:
+
+1. versioned executable configuration, tests, and workflow files;
+2. `docs/repo/ACTIVE_SURFACES.json` and accepted ADRs;
+3. `README.md`, `CONTRIBUTING.md`, and `docs/START_HERE.md`;
+4. focused architecture and operations docs;
+5. audit, migration, incident, and release records.
+
+Historical records describe what was true at a point in time. Do not silently
+rewrite their old commands or outcomes; label or supersede them when readers
+might mistake them for current guidance.
+
+## Document classes
+
+| Class               | Examples                                             | Maintenance rule                                             |
+| ------------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| Entry point         | `README.md`, `CONTRIBUTING.md`, `docs/START_HERE.md` | Short, task-oriented, and updated with every contract change |
+| Canonical reference | architecture, onboarding, operations, ADRs           | Own one topic and link rather than duplicate                 |
+| Generated evidence  | reports and scan summaries                           | Regenerate from the owning command; do not hand-edit results |
+| Historical record   | `docs/audit/`, `docs/migration/`, incidents          | Preserve evidence and date; add a status note if superseded  |
+
+## Freshness rules
+
+- Update docs in the same pull request as changes to commands, paths, supported
+  runtimes, ownership, public contracts, or validation requirements.
+- Use `Verified: YYYY-MM-DD` only on volatile operational or provider-dependent
+  guidance. Change the date only after checking the content against its source.
+- Treat a doc as suspect when it names a missing path or script, conflicts with
+  `package.json`, describes a removed workflow, or points to an old runtime as
+  current.
+- Review entry points and operational docs at least quarterly, and after every
+  runtime migration, release-gate change, deployment incident, or major
+  dependency upgrade.
+- Prefer deletion or replacement of stale instructions over accumulating
+  warnings and exceptions.
+
+## Writing for humans
+
+- Lead with the outcome and the safe default command.
+- State prerequisites before steps and expected results after them.
+- Use tables for exact mappings, lists for choices, and prose for rationale.
+- Expand uncommon acronyms on first use. Use the same term for the same concept.
+- Keep examples copyable and platform caveats beside the affected command.
+- Separate required steps from optional or manual-only work.
+- Link to detail instead of copying it. A fact should have one canonical owner.
+- Preserve accents and product naming: **El Rincón de Ébano**.
+
+## Review checklist
+
+- [ ] Commands and paths exist and match `package.json` or the owning workflow.
+- [ ] Runtime versions match `.nvmrc`, `.node-version`, `.tool-versions`, and CI.
+- [ ] Required, optional, live-network, and destructive steps are distinguishable.
+- [ ] Entry points link to the new or changed document.
+- [ ] No canonical fact is maintained in multiple detailed copies.
+- [ ] Examples are minimal, safe, and copyable.
+- [ ] Historical evidence was preserved rather than rewritten as current truth.
+- [ ] Markdown lint and the relevant repository validation pass.
+
+## Ownership
+
+The author of a behavior change owns the corresponding doc update. Reviewers
+should treat stale commands and broken navigation as defects, not follow-up
+polish. For complex doc work, record scope, decisions, and validation in a
+versioned plan under `docs/audit/`.

--- a/docs/operations/EDGE_SECURITY_HEADERS.md
+++ b/docs/operations/EDGE_SECURITY_HEADERS.md
@@ -32,12 +32,14 @@ Rutas mínimas de verificación operativa:
 
 ## Política objetivo
 
-Source of truth repo-side: [tools/security-header-policy.mjs](/home/carlos/VS_Code_Projects/Tienda%20Ebano/tools/security-header-policy.mjs)
+Source of truth repo-side:
+[`tools/security-header-policy.mjs`](../../tools/security-header-policy.mjs)
 
 Implementación lista para aplicar:
 
-- Worker: [worker.mjs](/home/carlos/VS_Code_Projects/Tienda%20Ebano/infra/cloudflare/edge-security-headers/worker.mjs)
-- Template Wrangler: [wrangler.toml.example](/home/carlos/VS_Code_Projects/Tienda%20Ebano/infra/cloudflare/edge-security-headers/wrangler.toml.example)
+- Worker: [`worker.mjs`](../../infra/cloudflare/edge-security-headers/worker.mjs)
+- Template Wrangler:
+  [`wrangler.toml.example`](../../infra/cloudflare/edge-security-headers/wrangler.toml.example)
 - Script de deploy: `npm run cloudflare:deploy:edge-security-headers`
 - Workflow de deploy: `Deploy Cloudflare Edge Security Headers`
 

--- a/docs/operations/QUALITY_GUARDRAILS.md
+++ b/docs/operations/QUALITY_GUARDRAILS.md
@@ -1,9 +1,9 @@
-# Quality Guardrails (Prompt 1)
+# Quality Guardrails
 
 ## Scope
 
 This document defines the baseline reliability rules for production changes in
-El Rincon de Ebano.
+El Rincón de Ébano.
 
 ## Global Definition of Done
 
@@ -108,5 +108,5 @@ Use this process in PR descriptions for risky changes:
 - Commits en Conventional Commits (`docs(agents): ...`).
 - PRs incluyen evidencia de `npm test`, `npm run build`, `npm run test:e2e` y auditorías relevantes.
 - Actualizar docs relacionadas en el mismo PR cuando cambia un comportamiento.
-- Adjuntar `npm audit --production` cuando se toquen dependencias.
+- Adjuntar `npm audit --omit=dev` cuando se toquen dependencias de producción.
 - Patch/minor permitidos si pruebas y auditorías en verde. Major requieren RFC documentado.

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -186,7 +186,7 @@ Fallback sin `node` en PATH: `npx -y node@24 "C:\Program Files\nodejs\node_modul
 | Type & Lint Guardian    | `npm run typecheck`                                                                                                 | PRs en `src/js/**`                   | Sin errores tsc                                    |
 | Type & Lint Guardian    | `npm run format`                                                                                                    | Cada PR                              | Código formateado                                  |
 | Type & Lint Guardian    | `npm run guardrails:assets`                                                                                         | PRs con cambios en imágenes/catálogo | Sin assets huérfanos nuevos                        |
-| Security / Supply Chain | `npm audit --production`                                                                                            | Mensual o ante cambios de deps       | Sin vulns altas/críticas                           |
+| Security / Supply Chain | `npm audit --omit=dev`                                                                                              | Mensual o ante cambios de deps       | Sin vulns altas/críticas                           |
 | Security / Supply Chain | `pip-audit -r admin/product_manager/requirements.lock.txt`                                                          | Cambios en tooling Python            | Sin vulns altas/críticas                           |
 | Security / Supply Chain | `npm run security:secret-scan`                                                                                      | Cada PR/push                         | Sin credenciales en versión                        |
 | Security / Supply Chain | `semgrep scan --config p/default --config p/secrets --metrics=off --sarif --output reports/semgrep/results.sarif .` | CI o reproducción local              | SARIF generado y subido                            |
@@ -204,7 +204,7 @@ Fallback sin `node` en PATH: `npx -y node@24 "C:\Program Files\nodejs\node_modul
 - **`Semgrep Security Scan`** (`.github/workflows/semgrep.yml`) — push/PR a `main`, cron semanal. Instala desde `tools/requirements-semgrep.txt`; escanea con `p/default` + `p/secrets`; sube SARIF.
 - **`Secret Scan`** (`.github/workflows/secret-scan.yml`) — push/PR, cron semanal. Ejecuta `npm run security:secret-scan`.
 - **`Continuous Integration`** (`.github/workflows/ci.yml`) — push/PR a `main` (excluye `admin/**`). Node 24.x: lint root + Astro, build, guardrails, unit tests, E2E, smoke, Lighthouse.
-- **`CI Guardrails`** (`.github/workflows/ci-guardrails.yml`) — push/PR a `main`. Node 24.x: build, lint de imágenes y guardrails rápidos para regressions operativas.
+- **`Quality Gates`** (`.github/workflows/quality-gates.yml`) — push/PR a `main`, cron semanal y manual. Verifica complejidad, vulnerabilidades, scripts shell, workflows y Markdown.
 - **`Security Audits`** (`.github/workflows/security-audit.yml`) — cron semanal / manual. Node 24.x en las superficies npm; `pip-audit` para el tooling Python.
 - **`Post-Deploy Canary`** (`.github/workflows/post-deploy-canary.yml`) — PR a `main`, `workflow_run` post-deploy. Live probe solo en runner self-hosted; modo estricto de headers en `/` y `/pages/bebidas.html`.
 - **`Live Contract Monitor`** (`.github/workflows/live-contract-monitor.yml`) — cron diario. Runner self-hosted (Cloudflare puede challengear runners GitHub-hosted con `403`). Abre/actualiza issue si falla el baseline de headers y exige `gh` CLI presente en el runner.
@@ -223,7 +223,7 @@ Fallback sin `node` en PATH: `npx -y node@24 "C:\Program Files\nodejs\node_modul
 
 1. `npm pkg get dependencies["<paquete>"]` — versión actual.
 2. Patch/minor: `npm install <paquete>@latest --save`; verificar `package-lock.json`.
-3. Correr `npm audit --production`, `npm test`, `npm run build`; documentar resultados.
+3. Correr `npm audit --omit=dev`, `npm test`, `npm run build`; documentar resultados.
 4. Major: preparar RFC (alcance, breaking changes, plan de validación) antes del PR.
 
 ### Depurar fallos de CI

--- a/docs/operations/VALIDATION_MATRIX.md
+++ b/docs/operations/VALIDATION_MATRIX.md
@@ -12,7 +12,17 @@ release readiness.
 
 ## Release gate contents
 
-`npm run validate:release` runs the following stages in order:
+`npm run validate` runs the following stages in order:
+
+1. `npm run lint`
+2. `npm run typecheck`
+3. `npm run check:e2e-selectors`
+4. `npm test`
+5. `npm run build`
+6. `npm run guardrails:assets`
+
+`npm run validate:release` runs the release stages explicitly defined in
+`tools/validate-release.mjs`:
 
 1. `npm run lint`
 2. `npm run typecheck`
@@ -28,6 +38,7 @@ release readiness.
 | ------------------------------- | ---------------------------------------------------------------------------- |
 | `npm run lint`                  | Every change.                                                                |
 | `npm run typecheck`             | Runtime, shared JS, or Astro source changes.                                 |
+| `npm run check:e2e-selectors`   | Storefront markup, styles, or browser-test selector changes.                 |
 | `npm test`                      | Every behavior change.                                                       |
 | `npm run build`                 | Any change that affects shipped output or generated assets.                  |
 | `npm run guardrails:assets`     | Images, catalog data, taxonomy, or build-tooling changes.                    |
@@ -38,5 +49,8 @@ release readiness.
 
 - `npm run build` remains the only supported build path.
 - `npm run validate` is intentionally lighter than the release gate.
+- The local baseline owns `check:e2e-selectors`; the release runner currently
+  defines its stages independently rather than invoking `npm run validate`.
+- `monitor:share-preview` is a live-network check against the deployed site.
 - If the release gate needs to change, update this file, `package.json`, and the
   ADR index together.

--- a/docs/repo/STRUCTURE.md
+++ b/docs/repo/STRUCTURE.md
@@ -1,19 +1,15 @@
 # Repository Structure and Conventions
 
-## Dual-root layout
+## npm workspace layout
 
-This repo has **two `package.json` roots**. A full cold-start install requires both:
-
-```bash
-npm ci                   # root tooling, tests, guardrails
-(cd astro-poc && npm ci) # Astro storefront dependencies
-```
-
-Or use the single `bootstrap` script:
+This repo has a root package and the `astro-poc` workspace. The root lockfile
+installs both with one deterministic command:
 
 ```bash
 npm run bootstrap
 ```
+
+Do not run a separate install inside `astro-poc/`.
 
 The canonical cold-start instructions live in
 [`docs/onboarding/BOOTSTRAP.md`](../onboarding/BOOTSTRAP.md).
@@ -35,7 +31,7 @@ The canonical production build is always `npm run build` from the repo root — 
 | `config/`    | Shared config inputs consumed by tooling (e.g., `category_og_icon_map.json`).                                                 |
 | `infra/`     | Cloudflare Workers config (`wrangler.toml`) for edge security headers. Not part of the static build.                          |
 | `admin/`     | Python-based desktop product manager. Separate venv; CI via `admin.yml`.                                                      |
-| `reports/`   | Committed report artifacts (Lighthouse, canary, orphan-assets, smoke evidence).                                               |
+| `reports/`   | Generated evidence; ignored by default, with selected baselines committed explicitly.                                         |
 | `build/`     | Legacy asset manifest artifact. Not used by the Astro build path.                                                             |
 | `output/`    | Playwright trace/report output. Not committed.                                                                                |
 | `coverage/`  | Test coverage output. Not committed.                                                                                          |
@@ -112,7 +108,6 @@ Manual/specialized scripts are kept for targeted maintenance tasks and should no
   - Unit/integration: `test/*.test.js` or `test/*.spec.js`.
   - E2E Playwright (active): `test/e2e-astro/*.spec.ts`.
   - Supplemental/manual Playwright: `test/e2e/*.spec.ts`.
-  - Supplemental/manual Cypress: `cypress/e2e/*.cy.ts`.
   - Archived legacy storefront checks live under `_archive/legacy-storefront/tests/` and are outside the active assurance path.
 - Documentation:
   - Prompt checkpoints: `docs/audit/prompt-<N>-<topic>-YYYYMMDD.md`.


### PR DESCRIPTION
## What changed

- rewrote the README around quick start, architecture, validation, and documentation navigation
- added current AI/API token-efficiency and documentation-freshness guidance
- documented pragmatic DRY, SOLID, and KISS expectations
- repaired verified stale workspace, validation, workflow, Cypress, audit-command, and link references

## Why

Repository guidance had drifted from the npm workspace, executable validation stages, and active workflow/test surfaces. The human entry points also needed a clearer route from setup to contribution and operations.

## Impact

Documentation only. Runtime and deployment behavior are unchanged. Historical audit and migration evidence remains intact except for portable link repairs.

## Validation

- `npm run validate`
- Prettier check
- Markdown lint: 83 files, 0 errors
- local Markdown links: 78 files, no missing targets
- `git diff --check`

The repository baseline reports existing non-blocking lint complexity warnings and Astro hints, with no validation errors.