### PR TITLE
refactor(observability): restore legacy module as re-export of active module

### DIFF
--- a/src/js/modules/observability.mjs
+++ b/src/js/modules/observability.mjs
@@ -1,0 +1,4 @@
+export {
+  initObservability,
+  getObservabilitySnapshot,
+} from '../../astro-poc/src/scripts/storefront/observability.js';


### PR DESCRIPTION
Completes plan 020: the legacy observability.mjs was deleted but its consumer (main.js) still dynamically imports it. Restoring it as a re-export of the active module per plan spec.