### PR TITLE
fix(typecheck): remove dead broken observability re-export shim

### DIFF
--- a/src/js/modules/observability.mjs
+++ b/src/js/modules/observability.mjs
@@ -1,4 +1,0 @@
-export {
-  initObservability,
-  getObservabilitySnapshot,
-} from '../../astro-poc/src/scripts/storefront/observability.js';


### PR DESCRIPTION
## Problem
The CI **Typecheck** job (`tsc -p tsconfig.typecheck.json`) fails on `main`:

```
Cannot find module '../../astro-poc/src/scripts/storefront/observability.js'
src/js/modules/observability.mjs:4
```

The shim added in #383 has two faults: the import path is one `../` too shallow, **and** it re-exports `initObservability` / `getObservabilitySnapshot` — names the active module never exports (it only exports the `createObservabilityModule` factory). So even a path fix would just change the error to "no exported member".

## Fix
Delete the shim. It has **zero importers** anywhere in the repo, never functioned as written, and plan 037 already treats this path as removed with `astro-poc/src/scripts/storefront/observability.js` as canonical. This avoids config carve-outs and avoids touching the active module (which carries grandfathered lint debt).

## Verification
- `npm run typecheck` → 0 errors
- `npm test` → 178 passing

## Note (follow-up, not in this PR)
lint-staged runs the astro-poc ESLint config from the repo root, so staging any astro-poc `.js` throws false `no-undef` errors for browser globals. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)