### PR TITLE
fix(edge): pin offline-page style hash + ADR 0008 (enforced edge contract)

### DIFF
--- a/docs/adr/0008-enforced-edge-security-contract.md
+++ b/docs/adr/0008-enforced-edge-security-contract.md
@@ -1,0 +1,72 @@
+# ADR 0008: Enforced edge security contract for live production
+
+- Date: 2026-07-15
+- Status: Accepted
+
+## Context
+
+GitHub Pages is the content origin behind a Cloudflare edge (ADR 0004). The
+security headers and the "clean" public-HTML surface that the edge is supposed to
+present are versioned in [`tools/security-header-policy.mjs`](../../tools/security-header-policy.mjs)
+and applied by the Worker in
+[`infra/cloudflare/edge-security-headers/`](../../infra/cloudflare/edge-security-headers/).
+
+Nothing continuously verified that **live production** matched that policy. The
+`Live Contract Monitor` workflow was meant to, but it probes from GitHub-hosted
+runners whose datacenter IPs Cloudflare challenges at the edge before the request
+reaches origin. A challenged probe returns `403` whether the site is up or down,
+so the monitor could only ever report `inconclusive` and re-filed a "blocked by
+Cloudflare" issue every run. It provided no real coverage, and two kinds of drift
+had accumulated unseen:
+
+1. The deployed Worker predated the CSP-hardening commits, so production emitted a
+   stale CSP (missing the Cloudflare Insights script hash; `style-src` still had
+   `'unsafe-inline'`).
+2. Cloudflare was injecting its own first-party scripts (Web Analytics inline
+   bootstrap, the `/cdn-cgi/challenge-platform/` sensor) into the HTML **after**
+   the Worker runs, which the Worker's sanitizer cannot remove.
+
+## Decision
+
+The edge security headers and the public-HTML surface are a **contract that live
+production must satisfy**, verified continuously by the Live Contract Monitor.
+When production drifts, we fix production (or its Cloudflare configuration) — we do
+**not** relax the contract to match the drift.
+
+Concretely:
+
+- **The monitor observes production through a header-gated bypass.** It sends a
+  secret header (`LIVE_MONITOR_BYPASS_TOKEN` → `x-live-monitor-token`) that a
+  Cloudflare WAF "Skip" rule matches to wave the observer past challenge-issuing
+  features. The rule is scoped to that header only and skips only challenge
+  products (Browser Integrity Check, Security Level) — never managed WAF, rate
+  limiting, or block rules. Free **Bot Fight Mode** is not skippable by any rule,
+  so it must be **off** for the observer to reach origin.
+- **Cloudflare's automatic script injection is disallowed, not accepted.** The
+  contract deliberately permits the _external_ Web Analytics beacon
+  (`static.cloudflareinsights.com/beacon.min.js`) but rejects Cloudflare's
+  _automatic inline_ injection and the challenge-platform sensor. Production must
+  therefore use **manual** Web Analytics (external beacon) and keep **JavaScript
+  Detections off** — not weaken the monitor's HTML-surface rules.
+- **`style-src` stays strict (`'self'`).** The self-contained offline fallback
+  page (`astro-poc/public/pages/offline.html`) must render with no network, so its
+  inline critical CSS is allowed via a pinned `'sha256-…'` hash rather than
+  `'unsafe-inline'`. A drift guard in
+  [`test/security-header-policy.test.js`](../../test/security-header-policy.test.js)
+  recomputes the hash from the page and fails if it is not pinned.
+
+## Consequences
+
+- The monitor is conclusive: it reports `passed`, or `failed` on genuine drift —
+  never a silent `inconclusive`. A red run is real signal about production.
+- Operating the bypass and clearing drift are documented in
+  [`docs/operations/LIVE_CONTRACT_MONITOR.md`](../operations/LIVE_CONTRACT_MONITOR.md)
+  and [`docs/operations/EDGE_SECURITY_HEADERS.md`](../operations/EDGE_SECURITY_HEADERS.md):
+  redeploy the Worker to correct header drift; use the two Cloudflare toggles above
+  to correct HTML-surface drift.
+- The bypass token is a shared secret held in the GitHub Actions secret and the WAF
+  rule; rotate it in both places if it leaks. Turning Bot Fight Mode off trades some
+  edge bot protection for observability; Browser Integrity Check remains active for
+  ordinary traffic.
+- Changing the offline page's inline CSS requires updating `OFFLINE_STYLE_HASH`;
+  the guard test makes that failure loud instead of silent.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,15 +15,16 @@ Create or update an ADR when a change:
 
 ## ADR list
 
-| ADR    | Status   | Summary                                                                      |
-| ------ | -------- | ---------------------------------------------------------------------------- |
-| `0001` | Accepted | Shared utilities for Cloudflare image URLs and structured logging.           |
-| `0002` | Accepted | Operational guardrails and data-contract discipline from the audit baseline. |
-| `0003` | Accepted | Astro storefront replaces the legacy EJS/Node runtime.                       |
-| `0004` | Accepted | GitHub Pages remains the content origin behind Cloudflare edge controls.     |
-| `0005` | Accepted | `data/` and `assets/` stay at repo root as shared build inputs.              |
-| `0006` | Accepted | Service worker caching uses independently versioned cache namespaces.        |
-| `0007` | Accepted | `npm run validate:release` is the canonical release-validation contract.     |
+| ADR    | Status   | Summary                                                                                    |
+| ------ | -------- | ------------------------------------------------------------------------------------------ |
+| `0001` | Accepted | Shared utilities for Cloudflare image URLs and structured logging.                         |
+| `0002` | Accepted | Operational guardrails and data-contract discipline from the audit baseline.               |
+| `0003` | Accepted | Astro storefront replaces the legacy EJS/Node runtime.                                     |
+| `0004` | Accepted | GitHub Pages remains the content origin behind Cloudflare edge controls.                   |
+| `0005` | Accepted | `data/` and `assets/` stay at repo root as shared build inputs.                            |
+| `0006` | Accepted | Service worker caching uses independently versioned cache namespaces.                      |
+| `0007` | Accepted | `npm run validate:release` is the canonical release-validation contract.                   |
+| `0008` | Accepted | Live production must satisfy the edge security contract; fix production, not the contract. |
 
 ## Maintenance notes
 

--- a/docs/operations/LIVE_CONTRACT_MONITOR.md
+++ b/docs/operations/LIVE_CONTRACT_MONITOR.md
@@ -126,17 +126,30 @@ Pasos:
    curl -sS  https://www.elrincondeebano.com/ | grep -o 'cdn-cgi/challenge-platform\|__CF$cv$params\|data-cf-beacon' | sort -u
    ```
 
-   - El CSP debe incluir el hash y `style-src 'self'` → arregla los hallazgos de headers.
-   - Si `/cdn-cgi/challenge-platform/` o el beacon **persisten tras el redeploy**, entonces
-     Cloudflare los inyecta aguas abajo del Worker (el Worker ya los sanea en su salida con
-     `sanitizePublicHtmlEdgeSurface`, pero el edge los reinyecta). Eso es ajuste de
-     **dashboard**, no de código:
-     - Challenge sensor (`__CF$cv$params`): Bot Fight Mode / detections de JS.
-     - Beacon de insights: Web Analytics con inyección automática → desactívala o migra al
-       snippet self-hosted (el hash de `script-src` ya lo contempla).
+   - El CSP debe incluir el hash y `style-src 'self'` → arregla los hallazgos de headers
+     (confirmado el 2026-07-15: el redeploy corrige el CSP de inmediato).
 
-No se puede decidir pre- vs post-Worker por análisis estático: es empírico. Redeplega
-primero y observa; solo si sobreviven, ve al dashboard.
+3. Corrige la superficie HTML en el **dashboard** (confirmado post-Worker: Cloudflare
+   inyecta estos scripts aguas abajo del Worker, con `cf-cache-status: DYNAMIC`, así que el
+   redeploy no los quita). No debilites el contrato; ajusta Cloudflare:
+   - **Bootstrap inline de insights** → Web Analytics: cambia de inyección _automática_ a
+     _manual_. Para conservar analítica, usa el beacon **externo**
+     (`static.cloudflareinsights.com/beacon.min.js`), que el contrato ya permite.
+   - **Sensor `/cdn-cgi/challenge-platform/` (`__CF$cv$params`)** → Security → Bots →
+     **JavaScript Detections: Off** (con Bot Fight Mode ya desactivado para el bypass).
+
+Por qué no se relaja el contrato: la regla de superficie HTML permite el beacon externo pero
+rechaza la inyección automática de Cloudflare. Eso es intencional; consulta
+[ADR 0008](../adr/0008-enforced-edge-security-contract.md).
+
+### Página offline y `style-src`
+
+`astro-poc/public/pages/offline.html` es autocontenida (CSS crítico inline, sin hoja externa)
+para renderizar sin red. Con `style-src 'self'` su estilo inline queda bloqueado, así que su
+hash está fijado en `OFFLINE_STYLE_HASH` dentro de
+[tools/security-header-policy.mjs](../../tools/security-header-policy.mjs). Si cambias esa
+página, actualiza el hash: el guard en `test/security-header-policy.test.js` lo recalcula y
+falla si no coincide. Es la única ruta con `<style>` inline; el resto usa CSS externo.
 
 ## Notas de seguridad
 

--- a/test/security-header-policy.test.js
+++ b/test/security-header-policy.test.js
@@ -22,7 +22,7 @@ test('buildSecurityHeadersPolicy returns the versioned edge baseline', async () 
     policy['content-security-policy'],
     /connect-src 'self' https:\/\/cloudflareinsights\.com https:\/\/static\.cloudflareinsights\.com/
   );
-  assert.match(policy['content-security-policy'], /style-src 'self'(?:;|$)/);
+  assert.match(policy['content-security-policy'], /style-src 'self' 'sha256-[^']+'(?:;|$)/);
   assert.doesNotMatch(policy['content-security-policy'], /style-src[^;]*'unsafe-inline'/);
   assert.match(policy['content-security-policy'], /frame-ancestors 'none'/);
 });
@@ -138,4 +138,37 @@ test('inspectPublicHtmlEdgeSurface flags inline Cloudflare insights bootstrap bu
   assert.match(sanitized.html, /static\.cloudflareinsights\.com\/beacon\.min\.js/);
   assert.doesNotMatch(sanitized.html, /challenge-platform/);
   assert.doesNotMatch(sanitized.html, /__CF\$cv\$params/);
+});
+
+test('style-src pins the offline fallback inline-style hash (drift guard)', async () => {
+  const { buildContentSecurityPolicy } = await loadModule();
+  const fs = require('node:fs');
+  const crypto = require('node:crypto');
+
+  const offlinePath = 'astro-poc/public/pages/offline.html';
+  const offlineHtml = fs.readFileSync(offlinePath, 'utf8');
+
+  // The offline fallback must stay self-contained (no external stylesheet) so it
+  // renders with no network; that is why its inline critical CSS needs a CSP hash.
+  assert.doesNotMatch(
+    offlineHtml,
+    /rel=["']stylesheet["']/i,
+    `${offlinePath} must not depend on an external stylesheet.`
+  );
+
+  const match = offlineHtml.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
+  assert.ok(match, `${offlinePath} should contain an inline <style> block.`);
+
+  const expectedHash = `sha256-${crypto.createHash('sha256').update(match[1], 'utf8').digest('base64')}`;
+  const styleSrc =
+    buildContentSecurityPolicy()
+      .split(';')
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith('style-src')) || '';
+
+  assert.ok(
+    styleSrc.includes(`'${expectedHash}'`),
+    `style-src must pin the offline inline-style hash '${expectedHash}'. If ${offlinePath} ` +
+      `changed, update OFFLINE_STYLE_HASH in tools/security-header-policy.mjs to match.`
+  );
 });

--- a/tools/security-header-policy.mjs
+++ b/tools/security-header-policy.mjs
@@ -1,6 +1,13 @@
 export const SECURITY_HEADER_BASELINE_ROUTES = Object.freeze(['/', '/pages/bebidas.html']);
 const CSP_SELF = "'self'";
 const CSP_NONE = "'none'";
+// Hash of the inline critical CSS in the self-contained offline fallback page
+// (astro-poc/public/pages/offline.html), which must render with no network and
+// therefore cannot use an external stylesheet. Pinning the hash keeps style-src
+// strict ('self') instead of relaxing to 'unsafe-inline'. The drift guard in
+// security-header-policy.test.js recomputes this from the page and fails if the
+// offline CSS changes without this hash being updated.
+const OFFLINE_STYLE_HASH = "'sha256-txruc9PJz00ka/r40Dz/BjbfCBZ9ZbTqVda8f/oiI2k='";
 
 export const SECURITY_HEADER_POLICY = Object.freeze({
   'referrer-policy': 'strict-origin-when-cross-origin',
@@ -23,7 +30,7 @@ export const CONTENT_SECURITY_POLICY_DIRECTIVES = Object.freeze([
       "'sha256-SvXHAIPcJdE6zuH0y1Xb0AUS/ZJCmBwN7SfMfiEj578='",
     ],
   ],
-  ['style-src', [CSP_SELF]],
+  ['style-src', [CSP_SELF, OFFLINE_STYLE_HASH]],
   ['img-src', [CSP_SELF, 'data:', 'https:']],
   ['font-src', [CSP_SELF, 'data:']],
   [


### PR DESCRIPTION
## Why
Redeploying the edge Worker hardened production CSP to `style-src 'self'`, which **blocks the offline fallback page's inline critical CSS**. `astro-poc/public/pages/offline.html` is self-contained (no external stylesheet, by design — it must render with no network), so it's the one route that needs inline `<style>`. Verified blast radius: home, category (`/c/`), product, 404, and category pages are all clean; only offline is affected.

## What
- **Pin the offline page's inline-style `sha256` hash** in `style-src` (mirrors the existing Cloudflare-Insights script hash) rather than relaxing to `'unsafe-inline'` — keeps the hardening.
- **Drift-guard test**: recomputes the hash from `offline.html` and fails if `style-src` doesn't pin it, so the hash can't silently rot.
- **ADR 0008**: records the decisions from restoring the Live Contract Monitor — production must satisfy the edge security + HTML-surface contract (fix production/Cloudflare config, *not* the contract); the header-gated WAF bypass; why Cloudflare's automatic script injection is disallowed (manual Web Analytics + JavaScript Detections off).
- Runbook updated with the confirmed remediation.

## Deploy note
This changes the policy the Worker bundles. After merge, **redeploy the edge Worker** so production emits the offline-style hash (the offline page is CSP-blocked until then).

`npm test` → all passing (incl. the new guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)