### PR TITLE
feat(analytics): Cloudflare Web Analytics manual beacon

### DIFF
--- a/astro-poc/src/layouts/BaseLayout.astro
+++ b/astro-poc/src/layouts/BaseLayout.astro
@@ -161,5 +161,15 @@ const resolvedSharePreview =
     <script>
       import '../scripts/storefront.js';
     </script>
+
+    {/* Cloudflare Web Analytics — manual external beacon. Auto-injection is disabled
+        so the edge does not inject an inline bootstrap; the external beacon is the
+        contract-allowed form (see docs/adr/0008-enforced-edge-security-contract.md). */}
+    <script
+      is:inline
+      type="module"
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "74a43f533d0249389be8cc99de91bfdc"}'
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Why
Cloudflare Web Analytics **auto-injection was disabled** at the edge so production HTML stays clean of the inline insights bootstrap (per ADR 0008 — the Live Contract Monitor's HTML-surface contract rejects Cloudflare's automatic injection). Without a manual beacon, analytics stops collecting.

## What
Add the **external** Web Analytics beacon to `BaseLayout.astro` (Astro `is:inline`, emitted verbatim). This is the contract-allowed form — external `src`, not an inline bootstrap — so the monitor stays green:
- HTML-surface check: `inspectPublicHtmlEdgeSurface` → `ok: true` (external beacon is explicitly allowed).
- CSP: `script-src` and `connect-src` already permit `static.cloudflareinsights.com`.

The `data-cf-beacon` token is a public site identifier (visible in page source by design), safe to commit.

Verified: beacon not flagged by the surface check; `astro check` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)