### PR TITLE
fix(csp): allow Plausible, drop unused Cloudflare Insights allowances

### DIFF
--- a/docs/adr/0008-enforced-edge-security-contract.md
+++ b/docs/adr/0008-enforced-edge-security-contract.md
@@ -42,12 +42,12 @@ Concretely:
   products (Browser Integrity Check, Security Level) — never managed WAF, rate
   limiting, or block rules. Free **Bot Fight Mode** is not skippable by any rule,
   so it must be **off** for the observer to reach origin.
-- **Cloudflare's automatic script injection is disallowed, not accepted.** The
-  contract deliberately permits the _external_ Web Analytics beacon
-  (`static.cloudflareinsights.com/beacon.min.js`) but rejects Cloudflare's
-  _automatic inline_ injection and the challenge-platform sensor. Production must
-  therefore use **manual** Web Analytics (external beacon) and keep **JavaScript
-  Detections off** — not weaken the monitor's HTML-surface rules.
+- **Cloudflare's automatic script injection is disallowed.** The site uses
+  Plausible (cookie-less analytics, loaded from `plausible.io` and allowlisted in
+  the CSP); Cloudflare Web Analytics is not used. Cloudflare's automatic inline
+  injection and the `/cdn-cgi/challenge-platform/` sensor are rejected by the
+  HTML-surface rules, so production must keep Cloudflare Web Analytics
+  auto-injection and **JavaScript Detections off** — not weaken the rules.
 - **`style-src` stays strict (`'self'`).** The self-contained offline fallback
   page (`astro-poc/public/pages/offline.html`) must render with no network, so its
   inline critical CSS is allowed via a pinned `'sha256-…'` hash rather than

--- a/docs/operations/LIVE_CONTRACT_MONITOR.md
+++ b/docs/operations/LIVE_CONTRACT_MONITOR.md
@@ -132,14 +132,15 @@ Pasos:
 3. Corrige la superficie HTML en el **dashboard** (confirmado post-Worker: Cloudflare
    inyecta estos scripts aguas abajo del Worker, con `cf-cache-status: DYNAMIC`, así que el
    redeploy no los quita). No debilites el contrato; ajusta Cloudflare:
-   - **Bootstrap inline de insights** → Web Analytics: cambia de inyección _automática_ a
-     _manual_. Para conservar analítica, usa el beacon **externo**
-     (`static.cloudflareinsights.com/beacon.min.js`), que el contrato ya permite.
+   - **Bootstrap inline de insights** → Web Analytics: desactiva la inyección _automática_
+     (auto-inject off). El sitio usa **Plausible** (`plausible.io`, en el CSP y en
+     `astro-poc/src/layouts/BaseLayout.astro`), no Cloudflare Web Analytics.
    - **Sensor `/cdn-cgi/challenge-platform/` (`__CF$cv$params`)** → Security → Bots →
      **JavaScript Detections: Off** (con Bot Fight Mode ya desactivado para el bypass).
 
-Por qué no se relaja el contrato: la regla de superficie HTML permite el beacon externo pero
-rechaza la inyección automática de Cloudflare. Eso es intencional; consulta
+Por qué no se relaja el contrato: la regla de superficie HTML rechaza la inyección automática
+de Cloudflare (challenge-platform y bootstrap de insights). El sitio usa Plausible para
+analítica, no Cloudflare Web Analytics. Eso es intencional; consulta
 [ADR 0008](../adr/0008-enforced-edge-security-contract.md).
 
 ### Página offline y `style-src`

--- a/test/security-header-policy.test.js
+++ b/test/security-header-policy.test.js
@@ -14,14 +14,9 @@ test('buildSecurityHeadersPolicy returns the versioned edge baseline', async () 
   assert.equal(policy['referrer-policy'], 'strict-origin-when-cross-origin');
   assert.equal(policy['x-content-type-options'], 'nosniff');
   assert.equal(policy['x-frame-options'], 'DENY');
-  assert.match(
-    policy['content-security-policy'],
-    /script-src 'self' https:\/\/static\.cloudflareinsights\.com/
-  );
-  assert.match(
-    policy['content-security-policy'],
-    /connect-src 'self' https:\/\/cloudflareinsights\.com https:\/\/static\.cloudflareinsights\.com/
-  );
+  assert.match(policy['content-security-policy'], /script-src 'self' https:\/\/plausible\.io/);
+  assert.match(policy['content-security-policy'], /connect-src 'self' https:\/\/plausible\.io/);
+  assert.doesNotMatch(policy['content-security-policy'], /cloudflareinsights/);
   assert.match(policy['content-security-policy'], /style-src 'self' 'sha256-[^']+'(?:;|$)/);
   assert.doesNotMatch(policy['content-security-policy'], /style-src[^;]*'unsafe-inline'/);
   assert.match(policy['content-security-policy'], /frame-ancestors 'none'/);
@@ -56,7 +51,7 @@ test('inspectSecurityHeaders rejects drifted CSP and frame policy values', async
   );
   assert.match(
     inspection.invalid.join('\n'),
-    /content-security-policy \(script-src expected "'self' https:\/\/static\.cloudflareinsights\.com/
+    /content-security-policy \(script-src expected "'self' https:\/\/plausible\.io/
   );
   assert.match(inspection.invalid.join('\n'), /referrer-policy/);
   assert.match(inspection.invalid.join('\n'), /x-frame-options/);

--- a/tools/security-header-policy.mjs
+++ b/tools/security-header-policy.mjs
@@ -22,21 +22,15 @@ export const CONTENT_SECURITY_POLICY_DIRECTIVES = Object.freeze([
   ['base-uri', [CSP_SELF]],
   ['object-src', [CSP_NONE]],
   ['frame-ancestors', [CSP_NONE]],
-  [
-    'script-src',
-    [
-      CSP_SELF,
-      'https://static.cloudflareinsights.com',
-      "'sha256-SvXHAIPcJdE6zuH0y1Xb0AUS/ZJCmBwN7SfMfiEj578='",
-    ],
-  ],
+  // Plausible Analytics (cookie-less) is the site's analytics, loaded from
+  // plausible.io in BaseLayout.astro. Cloudflare Web Analytics is not used, so its
+  // insights origins/hash are intentionally absent (auto-injection is disabled and
+  // the HTML-surface rules still flag it if the edge injects it).
+  ['script-src', [CSP_SELF, 'https://plausible.io']],
   ['style-src', [CSP_SELF, OFFLINE_STYLE_HASH]],
   ['img-src', [CSP_SELF, 'data:', 'https:']],
   ['font-src', [CSP_SELF, 'data:']],
-  [
-    'connect-src',
-    [CSP_SELF, 'https://cloudflareinsights.com', 'https://static.cloudflareinsights.com'],
-  ],
+  ['connect-src', [CSP_SELF, 'https://plausible.io']],
   ['manifest-src', [CSP_SELF]],
   ['worker-src', [CSP_SELF]],
   ['form-action', [CSP_SELF]],


### PR DESCRIPTION
## Bug
The site's analytics is **Plausible** (cookie-less, `plausible.io`, in `BaseLayout.astro`), but the production CSP allowed **Cloudflare Insights** instead — so Plausible was **silently CSP-blocked** in production. With Cloudflare Web Analytics auto-injection now disabled, the site had no working analytics.

## Fix
- `script-src` / `connect-src`: allow `https://plausible.io`; remove the unused Cloudflare Insights origins (`cloudflareinsights.com`, `static.cloudflareinsights.com`) and the insights inline-script `sha256` hash. Cloudflare Web Analytics is not used.
- Resolves the prior contradiction where the CSP *allowed* the CF insights bootstrap while the HTML-surface rule *flagged* it — now the CSP and the surface rules agree (CF injection is neither allowed nor accepted).
- The offline-page `style-src` hash is untouched.
- Updates the policy tests, **ADR 0008**, and the runbook.

`npm test` → all passing.

## Deploy note
Requires a **Worker redeploy** after merge for production to emit the new CSP (then Plausible loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)