### PR TITLE
fix(security): canonicalize shared cart products (plan 026)

### DIFF
--- a/astro-poc/src/scripts/storefront.js
+++ b/astro-poc/src/scripts/storefront.js
@@ -14,9 +14,11 @@ import {
   createCartItemFromProduct,
   getCartState,
   hydrateCartFromOrder,
+  hydrateSharedCart,
   normalizeId,
   parseNumber,
   sanitizeCart,
+  toSharedCartPayload,
 } from './storefront/storefront-state.js';
 
 const MAX_RECENT_ORDERS = 6;
@@ -189,7 +191,9 @@ function showCartSaveError() {
 // Carrito compartible por URL
 function encodeCart(cart) {
   try {
-    return btoa(encodeURIComponent(JSON.stringify(cart)));
+    const payload = toSharedCartPayload(cart);
+    if (!payload) return '';
+    return btoa(encodeURIComponent(JSON.stringify(payload)));
   } catch {
     return '';
   }
@@ -228,13 +232,15 @@ function loadCartFromUrl() {
   try {
     var raw = decodeCart(match[1]);
     if (!raw) return false;
-    var sanitized = sanitizeCart(raw);
-    if (sanitized.length === 0) return false;
+    var hydrated = hydrateSharedCart(raw, function (id) {
+      return getProductByIdFromSource(id) || getProductFromCard(getProductCardById(id));
+    });
+    if (hydrated.length === 0) return false;
 
     var currentCart = loadCart();
     if (currentCart.length > 0) return false;
 
-    if (!saveCart(sanitized)) {
+    if (!saveCart(hydrated)) {
       return false;
     }
     history.replaceState(null, '', globalThis.location.pathname + globalThis.location.search);
@@ -461,11 +467,18 @@ function getProductFromCard(card) {
 
   const name = card.dataset.productName || id;
   const category = card.dataset.productCategory || '';
-  const price = parseNumber(card.dataset.productFinalPrice, 0);
-  const image = card.querySelector('.product-thumb')?.getAttribute('src') || '';
+  const finalPrice = parseNumber(card.dataset.productFinalPrice, NaN);
+  const price = Number.isNaN(finalPrice)
+    ? Math.max(
+        0,
+        parseNumber(card.dataset.productPrice, 0) - parseNumber(card.dataset.productDiscount, 0)
+      )
+    : finalPrice;
+  const discount = parseNumber(card.dataset.productDiscount, 0);
+  const image = card.querySelector('.product-thumb, .strip-card__img')?.getAttribute('src') || '';
   const stock = card.dataset.productStock !== 'false';
 
-  return { id, name, category, price, image, stock };
+  return { id, name, category, price, discount, image, stock };
 }
 
 function getProductByIdFromSource(id) {

--- a/astro-poc/src/scripts/storefront/storefront-state.ts
+++ b/astro-poc/src/scripts/storefront/storefront-state.ts
@@ -106,3 +106,101 @@ export function hydrateCartFromOrder(order: unknown): CartItem[] {
     }))
   );
 }
+
+/**
+ * Shared-cart URL payload contract. The hash is untrusted input, so links
+ * carry identity and quantity only; display and pricing fields are rehydrated
+ * from the current catalog on load (plan 026).
+ */
+export const SHARED_CART_VERSION = 1;
+
+export interface SharedCartItem {
+  id: string;
+  quantity: number;
+}
+
+export interface SharedCartPayload {
+  version: number;
+  items: SharedCartItem[];
+}
+
+export function toSharedCartPayload(cart: unknown): SharedCartPayload | null {
+  const merged = new Map<string, number>();
+  for (const item of sanitizeCart(cart)) {
+    const id = normalizeId(item.id);
+    if (!id) {
+      continue;
+    }
+    const quantity = clampQty((merged.get(id) ?? 0) + clampQty(item.quantity));
+    if (quantity > 0) {
+      merged.set(id, quantity);
+    }
+  }
+  if (merged.size === 0) {
+    return null;
+  }
+  return {
+    version: SHARED_CART_VERSION,
+    items: [...merged.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([id, quantity]) => ({ id, quantity })),
+  };
+}
+
+export function parseSharedCartPayload(payload: unknown): SharedCartItem[] {
+  let rawItems: unknown;
+  if (Array.isArray(payload)) {
+    // Legacy link: full cart items were stored; only identity and quantity
+    // are trusted. Every other legacy field (name/price/discount/image) is ignored.
+    rawItems = payload;
+  } else {
+    const obj = payload as Record<string, unknown> | null | undefined;
+    if (!obj || typeof obj !== 'object') {
+      return [];
+    }
+    if (obj.version !== SHARED_CART_VERSION) {
+      return [];
+    }
+    if (!Array.isArray(obj.items)) {
+      return [];
+    }
+    rawItems = obj.items;
+  }
+
+  const seen = new Set<string>();
+  const items: SharedCartItem[] = [];
+  for (const raw of rawItems as unknown[]) {
+    const entry = raw as Record<string, unknown> | null | undefined;
+    const id = normalizeId(entry?.id);
+    const quantity = clampQty(entry?.quantity);
+    if (!id || quantity <= 0 || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    items.push({ id, quantity });
+  }
+  return items;
+}
+
+export function hydrateSharedCart(
+  payload: unknown,
+  resolveProductById: (id: string) => unknown
+): CartItem[] {
+  const entries = parseSharedCartPayload(payload);
+  if (entries.length === 0 || typeof resolveProductById !== 'function') {
+    return [];
+  }
+
+  const items: CartItem[] = [];
+  for (const { id, quantity } of entries) {
+    const product = resolveProductById(id) as Record<string, unknown> | null | undefined;
+    if (!product || product.stock === false) {
+      continue;
+    }
+    const item = createCartItemFromProduct(product, quantity);
+    if (item) {
+      items.push(item);
+    }
+  }
+  return items;
+}

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,32 +26,32 @@ los que siguen pendientes se confirman aquí como TODO con evidencia de la brech
 
 <!-- markdownlint-disable MD060 -->
 
-| Plan | Estado verificado | Evidencia de la brecha                                                                                                                  |
-| ---- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| 024  | DONE              | Runner único Vitest (2026-08-11): `run-all.js` eliminado, 15 script-tests legacy convertidos a suites, coverage unificado               |
-| 026  | TODO              | `storefront.js:192` sigue base64 del carrito completo; sin payload versionado `{version, items:[{id,quantity}]}` ni `hydrateSharedCart` |
-| 027  | TODO              | `hydrateCartFromOrder` (storefront-state.ts:92-107) sigue sin mapear `discount`                                                         |
-| 030  | TODO              | `server/productStore.js:315-320` sigue `writeFile` directo en ambos archivos; sin manifest/recovery                                     |
-| 031  | TODO              | `@astrojs/partytown` sigue en `astro.config.mjs` y deps; barrel completo de Bootstrap + `globalThis.bootstrap`                          |
-| 038  | TODO              | Sin ADR de funnel privado en `docs/adr/`                                                                                                |
-| 040  | TODO              | `bulk_operations_mixin.py` sigue construyendo `Product(...)` parcial ×5                                                                 |
-| 041  | TODO              | `product_form.py:767` sigue moviendo media inmediatamente en `_on_category_change`                                                      |
-| 042  | TODO              | `main_window.py:1430` sigue `products.pop(start_index)` (índice visible)                                                                |
-| 043  | TODO              | `main_window.py:795` sigue llamando `consume_conflicts()` para mostrar                                                                  |
-| 044  | TODO              | Modelo rechaza `discount > price`; formularios rechazan `>=` (fronteras distintas)                                                      |
-| 045  | TODO              | `deploy.py:249` sigue `success = True` incondicional; sin manifest/preflight                                                            |
-| 046  | TODO              | `deploy_panel.py` sigue síncrono; `AsyncOperation` (components.py) sin uso en el panel                                                  |
-| 047  | TODO              | `main_window.py:81,162-180` sigue leyendo `~/.product_manager/config.json`                                                              |
-| 049  | TODO              | `data_store.py` sigue presente sin callers                                                                                              |
-| 060  | TODO              | Preview sin binding durable (ID/hash/base-rev); sin CSV ni UX de archivo                                                                |
-| 061  | TODO              | Sin filtros min/max, duplicate, Git pull, prefs/shortcuts en TS; doctor CLI-only                                                        |
-| 063  | TODO              | `/media/generate` sigue `acknowledged`; upload directo sin staging/sniffing                                                             |
-| 064  | TODO              | `syncAdapter` sigue 501 para push/pull                                                                                                  |
-| 066  | TODO              | Sin editor de featured; schema de bundles sin invariantes (empty/unique/refs)                                                           |
-| 067  | TODO              | Solo `atomicWriter` pruna backups; categorías/storefront sin retención                                                                  |
-| 069  | TODO              | Terminal: Python sigue activo como fallback; depende de 056–068                                                                         |
-| 082  | PARTIAL           | `npm audit --omit=dev` ya 0 HIGH; falta retirar `test-web` y `admin/web`                                                                |
-| 083  | TODO              | Sin `categoryService` contract tests ni route tests de mutación; `ensureDiscountToggle` sigue siendo copia                              |
+| Plan | Estado verificado | Evidencia de la brecha                                                                                                          |
+| ---- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 024  | DONE              | Runner único Vitest (2026-08-11): `run-all.js` eliminado, 15 script-tests legacy convertidos a suites, coverage unificado       |
+| 026  | DONE              | Carrito compartido catálogo-autoritativo (2026-08-11): payload mínimo versionado, `hydrateSharedCart` con resolución DOM amplia |
+| 027  | TODO              | `hydrateCartFromOrder` (storefront-state.ts:92-107) sigue sin mapear `discount`                                                 |
+| 030  | TODO              | `server/productStore.js:315-320` sigue `writeFile` directo en ambos archivos; sin manifest/recovery                             |
+| 031  | TODO              | `@astrojs/partytown` sigue en `astro.config.mjs` y deps; barrel completo de Bootstrap + `globalThis.bootstrap`                  |
+| 038  | TODO              | Sin ADR de funnel privado en `docs/adr/`                                                                                        |
+| 040  | TODO              | `bulk_operations_mixin.py` sigue construyendo `Product(...)` parcial ×5                                                         |
+| 041  | TODO              | `product_form.py:767` sigue moviendo media inmediatamente en `_on_category_change`                                              |
+| 042  | TODO              | `main_window.py:1430` sigue `products.pop(start_index)` (índice visible)                                                        |
+| 043  | TODO              | `main_window.py:795` sigue llamando `consume_conflicts()` para mostrar                                                          |
+| 044  | TODO              | Modelo rechaza `discount > price`; formularios rechazan `>=` (fronteras distintas)                                              |
+| 045  | TODO              | `deploy.py:249` sigue `success = True` incondicional; sin manifest/preflight                                                    |
+| 046  | TODO              | `deploy_panel.py` sigue síncrono; `AsyncOperation` (components.py) sin uso en el panel                                          |
+| 047  | TODO              | `main_window.py:81,162-180` sigue leyendo `~/.product_manager/config.json`                                                      |
+| 049  | TODO              | `data_store.py` sigue presente sin callers                                                                                      |
+| 060  | TODO              | Preview sin binding durable (ID/hash/base-rev); sin CSV ni UX de archivo                                                        |
+| 061  | TODO              | Sin filtros min/max, duplicate, Git pull, prefs/shortcuts en TS; doctor CLI-only                                                |
+| 063  | TODO              | `/media/generate` sigue `acknowledged`; upload directo sin staging/sniffing                                                     |
+| 064  | TODO              | `syncAdapter` sigue 501 para push/pull                                                                                          |
+| 066  | TODO              | Sin editor de featured; schema de bundles sin invariantes (empty/unique/refs)                                                   |
+| 067  | TODO              | Solo `atomicWriter` pruna backups; categorías/storefront sin retención                                                          |
+| 069  | TODO              | Terminal: Python sigue activo como fallback; depende de 056–068                                                                 |
+| 082  | PARTIAL           | `npm audit --omit=dev` ya 0 HIGH; falta retirar `test-web` y `admin/web`                                                        |
+| 083  | TODO              | Sin `categoryService` contract tests ni route tests de mutación; `ensureDiscountToggle` sigue siendo copia                      |
 
 <!-- markdownlint-enable MD060 -->
 
@@ -653,13 +653,13 @@ además `cd admin/product_manager && python -m ruff check . && python -m pytest`
 
 ### Wave B — Storefront and CI improvements
 
-| Plan | Título                                     | Priority | Effort | Depends on      | Status                                                                                                           |
-| ---- | ------------------------------------------ | -------- | ------ | --------------- | ---------------------------------------------------------------------------------------------------------------- |
-| 026  | Canonicalizar carritos compartidos         | P1       | M      | 025             | TODO                                                                                                             |
-| 027  | Preservar descuentos y rollback de carrito | P1       | M      | 025             | TODO                                                                                                             |
-| 031  | Retirar Partytown y reducir Bootstrap JS   | P2       | M      | 025             | TODO                                                                                                             |
-| 035  | Consolidar builds duplicados de CI         | P2       | M      | —               | DONE — CI consolidado en job único `build-and-check` con par de determinismo y artefacto compartido (2026-08-10) |
-| 019  | Reducir Bootstrap CSS                      | P2       | M      | 031 recomendado | DONE                                                                                                             |
+| Plan | Título                                     | Priority | Effort | Depends on      | Status                                                                                                                    |
+| ---- | ------------------------------------------ | -------- | ------ | --------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 026  | Canonicalizar carritos compartidos         | P1       | M      | 025             | DONE — payload versionado `{version:1, items:[{id,quantity}]}`, hidratación desde catálogo, e2e link forjado (2026-08-11) |
+| 027  | Preservar descuentos y rollback de carrito | P1       | M      | 025             | TODO                                                                                                                      |
+| 031  | Retirar Partytown y reducir Bootstrap JS   | P2       | M      | 025             | TODO                                                                                                                      |
+| 035  | Consolidar builds duplicados de CI         | P2       | M      | —               | DONE — CI consolidado en job único `build-and-check` con par de determinismo y artefacto compartido (2026-08-10)          |
+| 019  | Reducir Bootstrap CSS                      | P2       | M      | 031 recomendado | DONE                                                                                                                      |
 
 **Gate**: `npm run validate` más los E2E focalizados de cada plan.
 

--- a/test/e2e-astro/cart-ux.spec.ts
+++ b/test/e2e-astro/cart-ux.spec.ts
@@ -310,3 +310,74 @@ test('T10: missing payment blocks submit — button disabled, error text shown',
   const openCount = await page.evaluate(() => (window as any).__openCallCount || 0);
   expect(openCount).toBe(0);
 });
+
+// ─── T11: Shared cart URL is catalog-authoritative (plan 026) ─────────────────
+
+test('T11: forged legacy shared-cart link rehydrates from catalog only', async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await waitForReady(page);
+
+  const firstCard = page.locator('.category-strip .add-to-cart-btn').first();
+  const card = firstCard.locator('xpath=ancestor::*[@data-product-id][1]');
+  const productId = await card.getAttribute('data-product-id');
+  const catalogName = await card.getAttribute('data-product-name');
+  expect(productId).toBeTruthy();
+  expect(catalogName).toBeTruthy();
+
+  // Forged legacy link: full cart shape with attacker-controlled commercial fields.
+  const forged = [
+    {
+      id: productId,
+      name: 'PRODUCTO FORJADO',
+      category: 'Fake',
+      price: 1,
+      discount: 0,
+      image: 'fake.jpg',
+      quantity: 2,
+    },
+  ];
+  const encoded = Buffer.from(encodeURIComponent(JSON.stringify(forged))).toString('base64');
+
+  await page.evaluate(() => localStorage.clear());
+  await page.evaluate((enc) => {
+    window.location.hash = `#cart=${enc}`;
+  }, encoded);
+  await page.reload({ waitUntil: 'networkidle' });
+  await waitForReady(page);
+
+  const shortcut = page.locator('#mobile-cart-shortcut');
+  await expect(shortcut).toBeVisible({ timeout: 5000 });
+  await shortcut.click();
+
+  const offcanvas = page.locator('#cartOffcanvas');
+  await expect(offcanvas).toBeVisible({ timeout: 5000 });
+
+  const title = offcanvas.locator('.cart-item__title');
+  await expect(title).toHaveText(catalogName!);
+
+  const stored = await page.evaluate(() => {
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      const value = localStorage.getItem(key);
+      if (value && value.includes('"id"') && value.includes('"quantity"')) {
+        try {
+          const parsed = JSON.parse(value);
+          if (Array.isArray(parsed)) return parsed;
+        } catch {
+          // keep scanning
+        }
+      }
+    }
+    return null;
+  });
+
+  expect(stored).not.toBeNull();
+  expect(stored![0]).toMatchObject({
+    id: productId,
+    name: catalogName,
+  });
+  expect(stored![0].price).toBeGreaterThan(1);
+  expect(stored![0].name).not.toBe('PRODUCTO FORJADO');
+});

--- a/test/storefront-state.spec.js
+++ b/test/storefront-state.spec.js
@@ -1,14 +1,19 @@
+/* eslint-disable max-lines-per-function -- suite-level describe block (plan 026) */
 import { describe, expect, it } from 'vitest';
 import {
   MAX_CART_ITEM_QTY,
+  SHARED_CART_VERSION,
   clampQty,
   createCartItemFromProduct,
   getCartState,
   hydrateCartFromOrder,
+  hydrateSharedCart,
   normalizeCartItem,
   normalizeId,
   parseNumber,
+  parseSharedCartPayload,
   sanitizeCart,
+  toSharedCartPayload,
 } from '../astro-poc/src/scripts/storefront/storefront-state.js';
 
 describe('storefront-state cart primitives', () => {
@@ -220,6 +225,147 @@ describe('storefront-state cart primitives', () => {
       expect(hydrateCartFromOrder(null)).toEqual([]);
       expect(hydrateCartFromOrder({ items: null })).toEqual([]);
       expect(hydrateCartFromOrder({})).toEqual([]);
+    });
+  });
+
+  describe('toSharedCartPayload', () => {
+    it('serializes identity and quantity only, omitting commercial fields', () => {
+      const payload = toSharedCartPayload([
+        {
+          id: 'p1',
+          name: 'Leche',
+          category: 'Lacteos',
+          price: 1500,
+          discount: 300,
+          image: 'leche.jpg',
+          quantity: 2,
+        },
+      ]);
+
+      expect(payload).toEqual({
+        version: SHARED_CART_VERSION,
+        items: [{ id: 'p1', quantity: 2 }],
+      });
+      expect(JSON.stringify(payload)).not.toContain('Leche');
+      expect(JSON.stringify(payload)).not.toContain('1500');
+      expect(JSON.stringify(payload)).not.toContain('discount');
+      expect(JSON.stringify(payload)).not.toContain('leche.jpg');
+    });
+
+    it('merges duplicate ids deterministically and clamps quantities', () => {
+      const payload = toSharedCartPayload([
+        { id: 'b', price: 500, quantity: 1 },
+        { id: 'a', price: 800, quantity: 999 },
+        { id: 'b', price: 0, quantity: 2 },
+      ]);
+
+      expect(payload.items).toEqual([
+        { id: 'a', quantity: MAX_CART_ITEM_QTY },
+        { id: 'b', quantity: 3 },
+      ]);
+    });
+
+    it('returns null for empty or invalid carts', () => {
+      expect(toSharedCartPayload([])).toBeNull();
+      expect(toSharedCartPayload(null)).toBeNull();
+      expect(toSharedCartPayload([{ id: '', quantity: 1 }])).toBeNull();
+    });
+  });
+
+  describe('parseSharedCartPayload', () => {
+    it('parses versioned payloads with capped and deduplicated items', () => {
+      const items = parseSharedCartPayload({
+        version: SHARED_CART_VERSION,
+        items: [
+          { id: 'p1', quantity: 1 },
+          { id: 'p2', quantity: 999 },
+          { id: 'p1', quantity: 3 },
+          { id: 'p3', quantity: 0 },
+          { id: '', quantity: 5 },
+        ],
+      });
+
+      expect(items).toEqual([
+        { id: 'p1', quantity: 1 },
+        { id: 'p2', quantity: MAX_CART_ITEM_QTY },
+      ]);
+    });
+
+    it('reads legacy array links by id and quantity only', () => {
+      const items = parseSharedCartPayload([
+        { id: 'p1', name: 'Fake', price: 1, discount: 2, image: 'x.jpg', quantity: 2 },
+        { id: 'p2', name: 'Also Fake', price: 9999, quantity: 1 },
+      ]);
+
+      expect(items).toEqual([
+        { id: 'p1', quantity: 2 },
+        { id: 'p2', quantity: 1 },
+      ]);
+    });
+
+    it('rejects malformed, non-array and unsupported-version payloads', () => {
+      expect(parseSharedCartPayload(null)).toEqual([]);
+      expect(parseSharedCartPayload('[]')).toEqual([]);
+      expect(parseSharedCartPayload({})).toEqual([]);
+      expect(parseSharedCartPayload({ version: 2, items: [{ id: 'p1', quantity: 1 }] })).toEqual(
+        []
+      );
+      expect(parseSharedCartPayload({ version: SHARED_CART_VERSION, items: 'nope' })).toEqual([]);
+    });
+  });
+
+  describe('hydrateSharedCart', () => {
+    const catalog = new Map([
+      ['p1', { id: 'p1', name: 'Leche', category: 'Lacteos', price: 1500, image: 'l.jpg' }],
+      ['p2', { id: 'p2', name: 'Pan', category: 'Panaderia', price: 800, discount: 100 }],
+      ['gone', null],
+      ['soldout', { id: 'soldout', name: 'Agotado', price: 100, stock: false }],
+    ]);
+    const resolve = (id) => catalog.get(id) ?? null;
+
+    it('rehydrates items from catalog values, ignoring forged commercial fields', () => {
+      const items = hydrateSharedCart(
+        {
+          version: SHARED_CART_VERSION,
+          items: [
+            { id: 'p1', name: 'Fake', price: 999999, discount: 0, quantity: 2 },
+            { id: 'p2', quantity: 1 },
+          ],
+        },
+        resolve
+      );
+
+      expect(items).toEqual([
+        expect.objectContaining({ id: 'p1', name: 'Leche', price: 1500, quantity: 2 }),
+        expect.objectContaining({ id: 'p2', name: 'Pan', price: 800, discount: 100, quantity: 1 }),
+      ]);
+    });
+
+    it('drops missing and out-of-stock products', () => {
+      const items = hydrateSharedCart(
+        {
+          version: SHARED_CART_VERSION,
+          items: [
+            { id: 'p1', quantity: 1 },
+            { id: 'gone', quantity: 1 },
+            { id: 'soldout', quantity: 1 },
+          ],
+        },
+        resolve
+      );
+
+      expect(items.map((item) => item.id)).toEqual(['p1']);
+    });
+
+    it('returns an empty cart for invalid payloads or missing resolver', () => {
+      expect(hydrateSharedCart(null, resolve)).toEqual([]);
+      expect(hydrateSharedCart({ version: 99, items: [] }, resolve)).toEqual([]);
+      expect(hydrateSharedCart([{ id: 'p1', quantity: 1 }], null)).toEqual([]);
+    });
+
+    it('supports legacy array links through the same catalog hydration', () => {
+      const items = hydrateSharedCart([{ id: 'p1', price: 1, quantity: 2 }], resolve);
+      expect(items).toEqual([expect.objectContaining({ id: 'p1', price: 1500, quantity: 2 })]);
     });
   });
 });


### PR DESCRIPTION
## Resumen

Plan 026 — los links compartidos de carrito solo transportan identidad y cantidad; precios/nombres se rehidratan del catálogo actual.

- `storefront-state.ts`: `SHARED_CART_VERSION`, `toSharedCartPayload` (payload mínimo `{version:1, items:[{id,quantity}]}`, dedup determinista + clamp), `parseSharedCartPayload` (rechaza malformados/versiones no soportadas; lee links legacy array solo id+quantity) y `hydrateSharedCart` (resuelve contra catálogo, descarta faltantes/agotados).
- `storefront.js`: `encodeCart` emite el payload mínimo; `loadCartFromUrl` hidrata desde el catálogo con resolución DOM amplia (`#product-container` + strips); `getProductFromCard` ahora deriva precio final/discount de `data-product-price/discount` cuando falta `data-product-final-price`.
- Tests: 11 unit tests nuevos (payload mínimo, dedup, legacy, forjados, out-of-stock) + E2E T11 con link legacy forjado verifica nombre/precio del catálogo.

Verificación: 417 unit tests, typecheck/lint OK, e2e cart-ux + storage-contract 13 passed.