### PR TITLE
fix: keep repeated orders and cart storage consistent (plan 027)

### DIFF
--- a/astro-poc/src/scripts/storefront.js
+++ b/astro-poc/src/scripts/storefront.js
@@ -1426,7 +1426,11 @@ function markOrderAsSent() {
     return;
   }
 
-  saveCart([]);
+  if (!saveCart([])) {
+    showCartSaveError();
+    return;
+  }
+
   saveStoredJson(STORAGE_SENT_KEY, Date.now());
   updateBadge([], { animate: true });
   renderCart([]);
@@ -1725,9 +1729,14 @@ function initStorefront() {
     if (!order || !Array.isArray(order.items) || order.items.length === 0) {
       return;
     }
-    cart = hydrateCartFromOrder(order);
+    const nextCart = hydrateCartFromOrder(order);
 
-    saveCart(cart);
+    if (!saveCart(nextCart)) {
+      showCartSaveError();
+      return;
+    }
+
+    cart = nextCart;
     updateBadge(cart, { animate: true });
     renderCart(cart, { animateTotal: true });
     renderCompanionSuggestions(cart, companionRules);
@@ -1884,8 +1893,11 @@ function initStorefront() {
     if (emptyBtn) {
       event.preventDefault();
       if (globalThis.confirm('¿Quieres vaciar el carrito completo?')) {
+        if (!saveCart([])) {
+          showCartSaveError();
+          return;
+        }
         cart = [];
-        saveCart(cart);
         updateBadge(cart, { animate: true });
         renderCart(cart, { animateTotal: true });
         syncAllActionAreas(cart);

--- a/astro-poc/src/scripts/storefront/storefront-state.ts
+++ b/astro-poc/src/scripts/storefront/storefront-state.ts
@@ -101,6 +101,7 @@ export function hydrateCartFromOrder(order: unknown): CartItem[] {
       name: item.name,
       category: item.category,
       price: item.price,
+      discount: item.discount,
       image: item.image,
       quantity: item.quantity,
     }))

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,32 +26,32 @@ los que siguen pendientes se confirman aquí como TODO con evidencia de la brech
 
 <!-- markdownlint-disable MD060 -->
 
-| Plan | Estado verificado | Evidencia de la brecha                                                                                                          |
-| ---- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| 024  | DONE              | Runner único Vitest (2026-08-11): `run-all.js` eliminado, 15 script-tests legacy convertidos a suites, coverage unificado       |
-| 026  | DONE              | Carrito compartido catálogo-autoritativo (2026-08-11): payload mínimo versionado, `hydrateSharedCart` con resolución DOM amplia |
-| 027  | TODO              | `hydrateCartFromOrder` (storefront-state.ts:92-107) sigue sin mapear `discount`                                                 |
-| 030  | TODO              | `server/productStore.js:315-320` sigue `writeFile` directo en ambos archivos; sin manifest/recovery                             |
-| 031  | TODO              | `@astrojs/partytown` sigue en `astro.config.mjs` y deps; barrel completo de Bootstrap + `globalThis.bootstrap`                  |
-| 038  | TODO              | Sin ADR de funnel privado en `docs/adr/`                                                                                        |
-| 040  | TODO              | `bulk_operations_mixin.py` sigue construyendo `Product(...)` parcial ×5                                                         |
-| 041  | TODO              | `product_form.py:767` sigue moviendo media inmediatamente en `_on_category_change`                                              |
-| 042  | TODO              | `main_window.py:1430` sigue `products.pop(start_index)` (índice visible)                                                        |
-| 043  | TODO              | `main_window.py:795` sigue llamando `consume_conflicts()` para mostrar                                                          |
-| 044  | TODO              | Modelo rechaza `discount > price`; formularios rechazan `>=` (fronteras distintas)                                              |
-| 045  | TODO              | `deploy.py:249` sigue `success = True` incondicional; sin manifest/preflight                                                    |
-| 046  | TODO              | `deploy_panel.py` sigue síncrono; `AsyncOperation` (components.py) sin uso en el panel                                          |
-| 047  | TODO              | `main_window.py:81,162-180` sigue leyendo `~/.product_manager/config.json`                                                      |
-| 049  | TODO              | `data_store.py` sigue presente sin callers                                                                                      |
-| 060  | TODO              | Preview sin binding durable (ID/hash/base-rev); sin CSV ni UX de archivo                                                        |
-| 061  | TODO              | Sin filtros min/max, duplicate, Git pull, prefs/shortcuts en TS; doctor CLI-only                                                |
-| 063  | TODO              | `/media/generate` sigue `acknowledged`; upload directo sin staging/sniffing                                                     |
-| 064  | TODO              | `syncAdapter` sigue 501 para push/pull                                                                                          |
-| 066  | TODO              | Sin editor de featured; schema de bundles sin invariantes (empty/unique/refs)                                                   |
-| 067  | TODO              | Solo `atomicWriter` pruna backups; categorías/storefront sin retención                                                          |
-| 069  | TODO              | Terminal: Python sigue activo como fallback; depende de 056–068                                                                 |
-| 082  | PARTIAL           | `npm audit --omit=dev` ya 0 HIGH; falta retirar `test-web` y `admin/web`                                                        |
-| 083  | TODO              | Sin `categoryService` contract tests ni route tests de mutación; `ensureDiscountToggle` sigue siendo copia                      |
+| Plan | Estado verificado | Evidencia de la brecha                                                                                                                                        |
+| ---- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 024  | DONE              | Runner único Vitest (2026-08-11): `run-all.js` eliminado, 15 script-tests legacy convertidos a suites, coverage unificado                                     |
+| 026  | DONE              | Carrito compartido catálogo-autoritativo (2026-08-11): payload mínimo versionado, `hydrateSharedCart` con resolución DOM amplia                               |
+| 027  | DONE              | Rollback persist-first (2026-08-11): `hydrateCartFromOrder` conserva discount, repeat/vaciar/mark-sent solo mutan tras `saveCart` OK; e2e con fault injection |
+| 030  | TODO              | `server/productStore.js:315-320` sigue `writeFile` directo en ambos archivos; sin manifest/recovery                                                           |
+| 031  | TODO              | `@astrojs/partytown` sigue en `astro.config.mjs` y deps; barrel completo de Bootstrap + `globalThis.bootstrap`                                                |
+| 038  | TODO              | Sin ADR de funnel privado en `docs/adr/`                                                                                                                      |
+| 040  | TODO              | `bulk_operations_mixin.py` sigue construyendo `Product(...)` parcial ×5                                                                                       |
+| 041  | TODO              | `product_form.py:767` sigue moviendo media inmediatamente en `_on_category_change`                                                                            |
+| 042  | TODO              | `main_window.py:1430` sigue `products.pop(start_index)` (índice visible)                                                                                      |
+| 043  | TODO              | `main_window.py:795` sigue llamando `consume_conflicts()` para mostrar                                                                                        |
+| 044  | TODO              | Modelo rechaza `discount > price`; formularios rechazan `>=` (fronteras distintas)                                                                            |
+| 045  | TODO              | `deploy.py:249` sigue `success = True` incondicional; sin manifest/preflight                                                                                  |
+| 046  | TODO              | `deploy_panel.py` sigue síncrono; `AsyncOperation` (components.py) sin uso en el panel                                                                        |
+| 047  | TODO              | `main_window.py:81,162-180` sigue leyendo `~/.product_manager/config.json`                                                                                    |
+| 049  | TODO              | `data_store.py` sigue presente sin callers                                                                                                                    |
+| 060  | TODO              | Preview sin binding durable (ID/hash/base-rev); sin CSV ni UX de archivo                                                                                      |
+| 061  | TODO              | Sin filtros min/max, duplicate, Git pull, prefs/shortcuts en TS; doctor CLI-only                                                                              |
+| 063  | TODO              | `/media/generate` sigue `acknowledged`; upload directo sin staging/sniffing                                                                                   |
+| 064  | TODO              | `syncAdapter` sigue 501 para push/pull                                                                                                                        |
+| 066  | TODO              | Sin editor de featured; schema de bundles sin invariantes (empty/unique/refs)                                                                                 |
+| 067  | TODO              | Solo `atomicWriter` pruna backups; categorías/storefront sin retención                                                                                        |
+| 069  | TODO              | Terminal: Python sigue activo como fallback; depende de 056–068                                                                                               |
+| 082  | PARTIAL           | `npm audit --omit=dev` ya 0 HIGH; falta retirar `test-web` y `admin/web`                                                                                      |
+| 083  | TODO              | Sin `categoryService` contract tests ni route tests de mutación; `ensureDiscountToggle` sigue siendo copia                                                    |
 
 <!-- markdownlint-enable MD060 -->
 
@@ -656,7 +656,7 @@ además `cd admin/product_manager && python -m ruff check . && python -m pytest`
 | Plan | Título                                     | Priority | Effort | Depends on      | Status                                                                                                                    |
 | ---- | ------------------------------------------ | -------- | ------ | --------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | 026  | Canonicalizar carritos compartidos         | P1       | M      | 025             | DONE — payload versionado `{version:1, items:[{id,quantity}]}`, hidratación desde catálogo, e2e link forjado (2026-08-11) |
-| 027  | Preservar descuentos y rollback de carrito | P1       | M      | 025             | TODO                                                                                                                      |
+| 027  | Preservar descuentos y rollback de carrito | P1       | M      | 025             | DONE — descuentos en reorden, persist-first en repeat/vaciar/mark-sent con toast de error (2026-08-11)                    |
 | 031  | Retirar Partytown y reducir Bootstrap JS   | P2       | M      | 025             | TODO                                                                                                                      |
 | 035  | Consolidar builds duplicados de CI         | P2       | M      | —               | DONE — CI consolidado en job único `build-and-check` con par de determinismo y artefacto compartido (2026-08-10)          |
 | 019  | Reducir Bootstrap CSS                      | P2       | M      | 031 recomendado | DONE                                                                                                                      |

--- a/test/e2e-astro/storage-contract.spec.ts
+++ b/test/e2e-astro/storage-contract.spec.ts
@@ -98,3 +98,158 @@ test('repeat-order flow keeps canonical last-order state usable after reload', a
   expect(persistedState.lastOrder?.payment).toBe('Efectivo');
   expect(Array.isArray(persistedState.lastOrder?.items)).toBe(true);
 });
+
+// ─── Plan 027: rollback discipline for destructive cart actions ──────────────
+
+async function completeOrderFlow(page: Page, productId: string) {
+  await page.locator(`.category-strip .add-to-cart-btn[data-id="${productId}"]`).first().click();
+  await page.locator('#cart-icon').click();
+  await page.locator('#cartOffcanvas').waitFor({ state: 'visible' });
+  await page.locator('#payment-cash').check();
+  await page.locator('#submit-cart').click();
+  await page.locator('#order-confirm-dialog').waitFor({ state: 'visible' });
+  await page.locator('#order-confirm-send').click();
+  await page.locator('#order-confirm-dialog').waitFor({ state: 'hidden', timeout: 10000 });
+  await page.waitForFunction(() => {
+    const lastOrder = JSON.parse(localStorage.getItem('astro-poc-last-order') || 'null');
+    return Array.isArray(lastOrder?.items) && lastOrder.items.length > 0;
+  });
+}
+
+function breakStorageWrites(page: Page) {
+  return page.evaluate(() => {
+    const proto = Storage.prototype;
+    (window as any).__restoreStorageWrites = () => {
+      proto.setItem = (window as any).__originalStorageSetItem;
+    };
+    (window as any).__originalStorageSetItem = proto.setItem;
+    proto.setItem = function (key: string, value: string) {
+      if (key === 'astro-poc-cart') {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      }
+      return (window as any).__originalStorageSetItem.call(this, key, value);
+    };
+  });
+}
+
+function restoreStorageWrites(page: Page) {
+  return page.evaluate(() => (window as any).__restoreStorageWrites?.());
+}
+
+test('repeat-order write failure keeps cart, badge and storage unchanged', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await waitForReady(page);
+  await page.evaluate(() => localStorage.clear());
+  await page.reload({ waitUntil: 'networkidle' });
+  await waitForReady(page);
+
+  const productId = await page
+    .locator('.category-strip .add-to-cart-btn')
+    .first()
+    .getAttribute('data-id');
+  expect(productId).toBeTruthy();
+
+  await page.evaluate(() => {
+    window.open = () => null;
+  });
+  await completeOrderFlow(page, productId!);
+  await page.reload({ waitUntil: 'networkidle' });
+  await waitForReady(page);
+
+  const badgeBefore = await page.locator('#cart-count').textContent();
+  await breakStorageWrites(page);
+
+  await page.locator('[data-repeat-last-order]').first().click();
+
+  await expect(page.locator('#cart-save-error')).toBeVisible();
+  await expect(page.locator('#cart-count')).toHaveText(badgeBefore!);
+  const cartAfter = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('astro-poc-cart') || '[]')
+  );
+  expect(cartAfter.length).toBe(1);
+  expect(cartAfter[0].id).toBe(productId);
+
+  await restoreStorageWrites(page);
+});
+
+test('empty-cart write failure keeps cart, badge and storage unchanged', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await waitForReady(page);
+  await page.evaluate(() => localStorage.clear());
+  await page.reload({ waitUntil: 'networkidle' });
+  await waitForReady(page);
+
+  const productId = await page
+    .locator('.category-strip .add-to-cart-btn')
+    .first()
+    .getAttribute('data-id');
+  expect(productId).toBeTruthy();
+
+  await page.locator(`.category-strip .add-to-cart-btn[data-id="${productId}"]`).first().click();
+  await page.waitForFunction(() => {
+    const cart = JSON.parse(localStorage.getItem('astro-poc-cart') || '[]');
+    return cart.length === 1;
+  });
+
+  const badgeBefore = await page.locator('#cart-count').textContent();
+  await page.evaluate(() => {
+    window.confirm = () => true;
+  });
+  await breakStorageWrites(page);
+
+  await page.locator('#cart-icon').click();
+  await page.locator('#cartOffcanvas').waitFor({ state: 'visible' });
+  await page.locator('.cart-note-toggle').click();
+  await page.locator('#empty-cart').click();
+
+  await expect(page.locator('#cart-save-error')).toBeVisible();
+  await expect(page.locator('#cart-count')).toHaveText(badgeBefore!);
+  const cartAfter = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('astro-poc-cart') || '[]')
+  );
+  expect(cartAfter.length).toBe(1);
+  expect(cartAfter[0].id).toBe(productId);
+
+  await restoreStorageWrites(page);
+});
+
+test('mark-sent write failure keeps cart, badge and sent marker unchanged', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await waitForReady(page);
+  await page.evaluate(() => localStorage.clear());
+  await page.reload({ waitUntil: 'networkidle' });
+  await waitForReady(page);
+
+  const productId = await page
+    .locator('.category-strip .add-to-cart-btn')
+    .first()
+    .getAttribute('data-id');
+  expect(productId).toBeTruthy();
+
+  await page.evaluate(() => {
+    window.open = () => null;
+  });
+  await completeOrderFlow(page, productId!);
+
+  await page.locator('#order-mark-sent').waitFor({ state: 'visible' });
+  const badgeBefore = await page.locator('#cart-count').textContent();
+  const sentBefore = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('astro-poc-order-last-sent-at') || '0')
+  );
+
+  await breakStorageWrites(page);
+  await page.locator('#order-mark-sent').click();
+
+  await expect(page.locator('#cart-save-error')).toBeVisible();
+  await expect(page.locator('#cart-count')).toHaveText(badgeBefore!);
+  const sentAfter = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('astro-poc-order-last-sent-at') || '0')
+  );
+  expect(sentAfter).toBe(sentBefore);
+  const cartAfter = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('astro-poc-cart') || '[]')
+  );
+  expect(cartAfter.length).toBe(1);
+
+  await restoreStorageWrites(page);
+});

--- a/test/storefront-state.spec.js
+++ b/test/storefront-state.spec.js
@@ -221,6 +221,21 @@ describe('storefront-state cart primitives', () => {
       expect(cart.map((item) => item.id)).toEqual(['p1', 'p2']);
     });
 
+    it('preserves discounts so repeated orders keep their effective total', () => {
+      const cart = hydrateCartFromOrder({
+        items: [
+          { id: 'p1', name: 'Leche', category: 'L', price: 1200, discount: 300, quantity: 2 },
+          { id: 'p2', name: 'Pan', category: 'P', price: 800, discount: 0, quantity: 1 },
+        ],
+      });
+
+      expect(cart.map((item) => ({ id: item.id, discount: item.discount }))).toEqual([
+        { id: 'p1', discount: 300 },
+        { id: 'p2', discount: 0 },
+      ]);
+      expect(getCartState(cart)).toEqual({ totalItems: 3, totalAmount: 2600 });
+    });
+
     it('returns an empty cart for invalid saved orders', () => {
       expect(hydrateCartFromOrder(null)).toEqual([]);
       expect(hydrateCartFromOrder({ items: null })).toEqual([]);


### PR DESCRIPTION
## Resumen

Plan 027 — disciplina persist-first en acciones destructivas del carrito.

- `hydrateCartFromOrder` preserva `discount`: repetir un pedido con descuento conserva su total efectivo.
- `repeatLastOrder`: calcula `nextCart` sin pisar el carrito; solo tras `saveCart` OK publica badge/render/profile/pago; fallo → `showCartSaveError` y estado previo intacto.
- Vaciar carrito (`#empty-cart`): `saveCart([])` primero; fallo → toast y carrito/UI sin cambios.
- `markOrderAsSent`: el marcador `orderLastSentAt` solo se escribe tras `saveCart([])` exitoso.
- E2E (storage-contract): 3 tests con fault injection quirúrgica (`Storage.setItem` lanza solo para `astro-poc-cart`) verificando toast + badge/carrito/marcador intactos; +1 unit test de descuento en hidratación.

Verificación: 418 unit tests, typecheck/lint OK, build OK, e2e cart-ux + storage-contract 16 passed.